### PR TITLE
Properly store lists as JSON

### DIFF
--- a/db.js
+++ b/db.js
@@ -38,7 +38,15 @@ class DB {
         pageHash,
         timestamp
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`;
-    return this.run(sql, Object.values(record));
+    return this.run(sql, Object.values(record).map(value => {
+      if (Object.prototype.toString.call(value) === "[object Date]") {
+        return value.toISOString();
+      } else if (typeof value === 'object') {
+        return JSON.stringify(value);
+      } else {
+        return value;
+      }
+    }));
   }
 
   run (sql, params = []) {


### PR DESCRIPTION
We want to store lists of e.g. links as a JSON object in SQLite. Currently the code stores them as a comma-separated list, which makes it harder to query. This changes the logic to store JS objects as JSON (unless they are Dates, in which case we store the ISO string).