### PR TITLE
Don't bother to store page host

### DIFF
--- a/db.js
+++ b/db.js
@@ -15,7 +15,6 @@ class DB {
     const sql = `
       CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (
         id PRIMARY KEY,
-        host TEXT,
         path TEXT,
         title TEXT,
         components TEXT,
@@ -30,14 +29,13 @@ class DB {
     const sql = `
       INSERT OR REPLACE INTO ${TABLE_NAME} (
         id,
-        host,
         path,
         title,
         components,
         links,
         pageHash,
         timestamp
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`;
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`;
     return this.run(sql, Object.values(record));
   }
 

--- a/index.js
+++ b/index.js
@@ -65,7 +65,6 @@ crawler.on('fetchcomplete', function (queueItem, responseBuffer) {
 
   const record = {
     id: parser.getID(queueItem.url),
-    host: queueItem.host,
     path: queueItem.path,
     title: parser.getTitle(),
     components: parser.getComponents(),


### PR DESCRIPTION
Since we're only crawling a single host, and we've told the crawler not to crawl URLs on other hosts, there's no point in keeping a `host` column in the database. Let's remove it to save a little space.