### PR TITLE
Create full-text search table

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ let APPROX_NUM_PAGES = 25900;
 
 // Set up the database
 const dbLocation = argv[2] || './cfgov.sqlite3';
-const db = new DB(dbLocation);
-db.createTable();
+const db = await DB.connect(dbLocation);
+await db.createTables();
 
 // Try and get the actual number of pages
 try {
@@ -66,7 +66,6 @@ crawler.on('fetchcomplete', async function (queueItem, responseBuffer) {
   const parser = new Parser(responseBuffer);
 
   const record = {
-    id: parser.getID(queueItem.url),
     path: queueItem.path,
     title: parser.getTitle(),
     components: parser.getComponents(),
@@ -77,7 +76,7 @@ crawler.on('fetchcomplete', async function (queueItem, responseBuffer) {
   };
 
   try {
-    db.insert(record);
+    await db.insert(record);
     progressBar.increment({path: record.path})
   } catch (error) {
     console.error("Something went horribly wrong and there's nothing to handle the exception. Oh no.");

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "html-minifier-terser": "^7.0.0-alpha.2",
     "md5": "^2.3.0",
     "simplecrawler": "^1.1.9",
+    "sqlite": "^4.0.25",
     "sqlite3": "^5.0.2"
   },
   "devDependencies": {

--- a/parser.js
+++ b/parser.js
@@ -11,11 +11,6 @@ class Parser {
     this.$ = cheerio.load(domBuffer);
   }
 
-  getID (url) {
-    // hash the full page url to get a unique identifier
-    return md5(url).substring(0, 10);
-  }
-
   getLinks () {
     const links = [];
     const $body = this.$('body');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2139,6 +2139,11 @@ sqlite3@^5.0.2:
   optionalDependencies:
     node-gyp "3.x"
 
+sqlite@^4.0.25:
+  version "4.0.25"
+  resolved "https://registry.yarnpkg.com/sqlite/-/sqlite-4.0.25.tgz#3710c6ea7dc94de4306f0bff77f916da02799605"
+  integrity sha512-gqCEcLF8FOTeW/na3SRYWLQkw2jZXgVj1DdgRJbm0jvrhnUgBIuNDUUm649AnBNDNHhI5XskwT8dvc8vearRLQ==
+
 sshpk@^1.7.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.17.0.tgz#578082d92d4fe612b13007496e543fa0fbcbe4c5"


### PR DESCRIPTION
This change adds a second SQLite table, `cfgov_fts`, which can be searched using SQLite FTS5 full-text search extension:

https://www.sqlite.org/fts5.html

This is created as an "external content table", which means that the main table content is not duplicated into the FTS table, but only referenced. This should significantly reduce the storage requirements of creating the FTS table.

A SQLite INSERT trigger is created to ensure that when content is added to the main table by the crawl, a reference to it gets added to the FTS table. I haven't created DELETE or UPDATE triggers as we shouldn't/won't be updating table content once it is written, but that is something we could do in future if need be:

https://www.sqlite.org/fts5.html#external_content_tables

This change also adopts the use of the [sqlite](https://www.npmjs.com/package/sqlite) Node package which allows for async/await interactions with the database.