### PR TITLE
Sort page links and components

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -23,7 +23,7 @@ class Parser {
       }
     });
 
-    return links;
+    return links.sort();
   }
 
   getHash () {
@@ -64,7 +64,7 @@ class Parser {
       });
     }
 
-    return components;
+    return components.sort();
   }
 }
 


### PR DESCRIPTION
Store page links and components in a sorted order, instead of the order they appear on the page.