### PR TITLE
Add database index for crawl timestamp

### DIFF
--- a/db.js
+++ b/db.js
@@ -31,6 +31,14 @@ class DB {
     `);
 
     await this.db.run(`
+      CREATE INDEX IF NOT EXISTS
+        ${TABLE_NAME}_timestamp_idx
+      ON ${TABLE_NAME} (
+        timestamp
+      )
+    `);
+
+    await this.db.run(`
       CREATE VIRTUAL TABLE IF NOT EXISTS ${TABLE_NAME}_fts USING fts5(
         path,
         pageHtml,


### PR DESCRIPTION
This commit adds a new database index for the `cfgov.timestamp` column. This significantly speeds up any DB queries that use this column, for example to find the minimum and maximum timestamps so as to determine when a particular crawl database was generated.