### PR TITLE
Pin sqlite3 version for compatibility with RHEL7

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "md5": "^2.3.0",
     "simplecrawler": "^1.1.9",
     "sqlite": "^4.0.25",
-    "sqlite3": "^5.0.2"
+    "sqlite3": "5.0.2"
   },
   "devDependencies": {
     "semistandard": "^16.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2300,7 +2300,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sqlite3@^5.0.2:
+sqlite3@5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-5.0.2.tgz#00924adcc001c17686e0a6643b6cbbc2d3965083"
   integrity sha512-1SdTNo+BVU211Xj1csWa8lV6KM0CtucDwRyA0VHl91wEH1Mgh7RxUpI4rVvG7OhHrzCSGaVyW5g8vKvlrk9DJA==


### PR DESCRIPTION
Versions of the Node sqlite3 package > 5.0.2 don't work on RHEL7 due to libstdc++ compatibility issue.

See https://github.com/TryGhost/node-sqlite3/issues/1582.

This commit pins the package to 5.0.2 to ensure compatibility.