### PR TITLE
Collapse django-debug-toolbar by default

### DIFF
--- a/viewer/settings.py
+++ b/viewer/settings.py
@@ -102,3 +102,8 @@ STATIC_URL = "static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 BASE_CRAWL_URL = "https://www.consumerfinance.gov"
+
+# django-debug-toolbar
+DEBUG_TOOLBAR_CONFIG = {
+    "SHOW_COLLAPSED": True,
+}


### PR DESCRIPTION
Currently the django-debug-toolbar sidebar is expanded by default. Let's collapse it by default instead.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/654645/172190954-ff91fbdc-1715-44e6-9c7e-c92fb972a76b.png">
