### PR TITLE
Improve UX by combining filter form and search form

### DIFF
--- a/viewer/viewer/static_src/crawsqueal.js
+++ b/viewer/viewer/static_src/crawsqueal.js
@@ -11,3 +11,18 @@ if ( breadcrumb ) {
     window.location.href = document.referrer;
   });
 }
+
+// Copy the sidebar filter values over to the search form so they're
+// submitted with the search term.
+const form = document.getElementById( 'search_form' );
+const filters = document.getElementById( 'filters' );
+if ( form && filters ) {
+  // Hide the sidebar's update button. It's only needed if JS is disabled.
+  document.getElementById( 'update-button' ).classList.add( 'u-hidden' );
+  form.addEventListener( 'submit', ev => {
+    const searchType = filters.querySelector( 'input[name="search_type"]:checked' ).value || 'links';
+    const paginateBy = filters.querySelector( 'input[name="paginate_by"]:checked' ).value || '50';
+    form.querySelector( 'input[name="search_type"]' ).value = searchType;
+    form.querySelector( 'input[name="paginate_by"]' ).value = paginateBy;
+  });
+}

--- a/viewer/viewer/templates/viewer/base_search.html
+++ b/viewer/viewer/templates/viewer/base_search.html
@@ -6,7 +6,7 @@
   </div>
   <div class="content_wrapper search_results">
     <div class="block block__flush-top">
-      <aside class="content_sidebar content__flush-top-on-small content__flush-sides-on-small filters">
+      <aside class="content_sidebar content__flush-top-on-small content__flush-sides-on-small filters" id="filters">
         {% include 'search_side_bar.html' %}
       </aside>
       <div class="content_main content__flush-all-on-small content__flush-bottom">

--- a/viewer/viewer/templates/viewer/search_form.html
+++ b/viewer/viewer/templates/viewer/search_form.html
@@ -1,5 +1,5 @@
 <div class="search_wrapper u-mt30">
-  <form action="{% url 'index' %}" data-js-hook="behavior_submit-search">
+  <form action="{% url 'index' %}" id="search_form">
     <input type="hidden" name="search_type" value="{{ form.search_type | default:'links' }}">
     <input type="hidden" name="paginate_by" value="{{ form.paginate_by | default:'50' }}">
     <h2 class="h4">Search terms</h2>

--- a/viewer/viewer/templates/viewer/search_side_bar.html
+++ b/viewer/viewer/templates/viewer/search_side_bar.html
@@ -1,6 +1,6 @@
 
     <h3>Refine results</h3>
-    <form action="{% url 'index' %}" method="get" data-js-hook="behavior_change-filter">
+    <form action="{% url 'index' %}" method="get">
       <input type="hidden" name="q" value="{{ form.q }}">
       <div>
         <div class="o-form_group u-mb30">
@@ -38,7 +38,7 @@
           </div>
         </fieldset>
       </div>
-      <div class="o-form_group u-mb30">
+      <div class="o-form_group u-mb30" id="update-button">
         <fieldset class="o-form_fieldset u-mt20">
           <div class="input-with-btn_btn">
             <button class="a-btn" type="submit">Update</button>


### PR DESCRIPTION
Currently there are two forms so if you change a sidebar option and also
the search term, you'd have to click both submit buttons. Some JS has been
added that syncs the sidebar values to the search form immediately before
submitting the search form.

Fixes https://github.com/cfpb/crawsqueal/issues/14