### PR TITLE
Add database download link to page footer

### DIFF
--- a/viewer/settings.py
+++ b/viewer/settings.py
@@ -53,9 +53,6 @@ ROOT_URLCONF = "urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [
-            os.path.join(BASE_DIR, "viewer/templates/viewer"),
-        ],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -72,6 +69,12 @@ WSGI_APPLICATION = "wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/4.0/ref/settings/#databases
 
+CRAWL_DATABASE = os.getenv(
+    "CRAWL_DATABASE",
+    str(BASE_DIR.parent / "crawl.sqlite3")
+)
+
+
 DATABASES = {
     "default": {},
     "empty": {
@@ -80,16 +83,11 @@ DATABASES = {
     },
     "crawl": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": "file:%s?mode=ro" % (
-            os.getenv(
-                "CRAWL_DATABASE",
-                str(BASE_DIR.parent / "crawl.sqlite3")
-            ),
-        ),
+        "NAME": f"file:{CRAWL_DATABASE}?mode=ro",
     },
 }
 
-DATABASE_ROUTERS = ["viewer.db_router.DatabaseRouter"]
+DATABASE_ROUTERS = ["viewer.database.DatabaseRouter"]
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.0/topics/i18n/

--- a/viewer/viewer/database.py
+++ b/viewer/viewer/database.py
@@ -1,16 +1,24 @@
+from django.conf import settings
 from django.db import OperationalError, connections
+
+
+def get_crawl_database_filename():
+    try:
+        connections["crawl"].cursor()
+    except OperationalError:
+        return None
+    else:
+        return settings.CRAWL_DATABASE
 
 
 class DatabaseRouter:
     route_app_labels = {"viewer"}
 
     def db_for_read(self, *args, **kwargs):
-        try:
-            connections["crawl"].cursor()
-        except OperationalError:
-            return "empty"
-        else:
+        if get_crawl_database_filename():
             return "crawl"
+        else:
+            return "empty"
 
     def db_for_write(self, *args, **kwargs):
         return None

--- a/viewer/viewer/templates/viewer/base.html
+++ b/viewer/viewer/templates/viewer/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load viewer %}
 
 <!DOCTYPE html>
 <html lang="en" class="no-js">
@@ -60,7 +61,29 @@
     </main>
     <footer class="o-footer">
       <div class="wrapper wrapper__match-content">
+        {% get_database_file_size as db_file_size %}
+        {% if db_file_size %}
         <div>
+          <ul class="o-footer_list m-list">
+            <li class="m-list_item">
+              <a class="m-list_link a-link a-link__icon"
+                href="{% url "download-database" %}"
+              >
+                <span class="a-link_text">
+                  Download raw SQLite database
+                </span>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 19" class="cf-icon-svg"><path d="M11.16 16.153a.477.477 0 0 1-.476.475H1.316a.476.476 0 0 1-.475-.475V3.046a.476.476 0 0 1 .475-.475h6.95l2.893 2.893zm-1.11-9.925H8.059a.575.575 0 0 1-.574-.573V3.679H1.95v11.84h8.102zm-1.234 5.604L6.388 14.26a.554.554 0 0 1-.784 0l-2.428-2.428a.554.554 0 1 1 .783-.784l1.483 1.482V7.41a.554.554 0 1 1 1.108 0v5.12l1.482-1.482a.554.554 0 0 1 .784.783z"></path></svg>
+              </a>
+              ({{ db_file_size | filesizeformat }}) to
+              <a class="m-list_link"
+                  href="https://github.com/cfpb/crawsqueal#how-to-query-the-crawler-database">
+                  explore the data locally
+              </a>
+            </li>
+          </ul>
+        </div>
+        {% endif %}
+        <div{% if db_file_size %} class="o-footer-post"{% endif %}>
           <div class="a-tagline a-tagline__large">
             <span class="u-usa-flag"></span>
             <div class="a-tagline_text"> An official website of the <span class="u-nowrap">United States government</span>

--- a/viewer/viewer/templates/viewer/base_search.html
+++ b/viewer/viewer/templates/viewer/base_search.html
@@ -1,13 +1,13 @@
-{% extends 'base.html' %}
+{% extends './base.html' %}
 
 {% block content %}
   <div class="content_wrapper search_form">
-    {% include 'search_form.html' %}
+    {% include './search_form.html' %}
   </div>
   <div class="content_wrapper search_results">
     <div class="block block__flush-top">
       <aside class="content_sidebar content__flush-top-on-small content__flush-sides-on-small filters" id="filters">
-        {% include 'search_side_bar.html' %}
+        {% include './search_side_bar.html' %}
       </aside>
       <div class="content_main content__flush-all-on-small content__flush-bottom">
         <section class="content_main-inner">

--- a/viewer/viewer/templates/viewer/page_detail.html
+++ b/viewer/viewer/templates/viewer/page_detail.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends './base.html' %}
 
 {% block content %}
   <div class="content_wrapper search_results">
@@ -6,7 +6,7 @@
       <div class="content__flush-all-on-small content__flush-bottom">
         <section class="content_main-inner">
           <nav class="breadcrumbs" aria-label="Breadcrumbs">
-            {% include 'icons/chevron-left.svg' %}
+            {% include './icons/chevron-left.svg' %}
             <a id="breadcrumb_link" class="breadcrumbs_link" href="{% url 'index' %}">
               Return to search results
             </a>
@@ -25,11 +25,11 @@
               <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                   <span class="u-visually-hidden-on-mobile">Show</span>
-                  {% include 'icons/plus-round.svg' %}
+                  {% include './icons/plus-round.svg' %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
                   <span class="u-visually-hidden-on-mobile">Hide</span>
-                  {% include 'icons/minus-round.svg' %}
+                  {% include './icons/minus-round.svg' %}
                 </span>
               </span>
             </button>
@@ -49,11 +49,11 @@
               <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                   <span class="u-visually-hidden-on-mobile">Show</span>
-                  {% include 'icons/plus-round.svg' %}
+                  {% include './icons/plus-round.svg' %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
                   <span class="u-visually-hidden-on-mobile">Hide</span>
-                  {% include 'icons/minus-round.svg' %}
+                  {% include './icons/minus-round.svg' %}
                 </span>
               </span>
             </button>
@@ -73,11 +73,11 @@
               <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                   <span class="u-visually-hidden-on-mobile">Show</span>
-                  {% include 'icons/plus-round.svg' %}
+                  {% include './icons/plus-round.svg' %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
                   <span class="u-visually-hidden-on-mobile">Hide</span>
-                  {% include 'icons/minus-round.svg' %}
+                  {% include './icons/minus-round.svg' %}
                 </span>
               </span>
             </button>

--- a/viewer/viewer/templates/viewer/page_list.html
+++ b/viewer/viewer/templates/viewer/page_list.html
@@ -1,4 +1,4 @@
-{% extends 'base_search.html' %}
+{% extends './base_search.html' %}
 
 {% block content_main %}
 <div class="results_header">
@@ -33,7 +33,7 @@
                   m-pagination_btn-prev">
         {% endif %}
         <span class="a-btn_icon a-btn_icon__on-left">
-          {% include 'icons/chevron-left.svg' %}
+          {% include './icons/chevron-left.svg' %}
         </span>
         Previous
       </a>
@@ -46,7 +46,7 @@
           {% endif %}
           Next
           <span class="a-btn_icon a-btn_icon__on-right">
-            {% include 'icons/chevron-right.svg' %}
+            {% include './icons/chevron-right.svg' %}
           </span>
         </a>
         <form class="m-pagination_form" action="{% if pagination_query_params %}?{{ pagination_query_params }}{% endif %}">

--- a/viewer/viewer/templates/viewer/search_form.html
+++ b/viewer/viewer/templates/viewer/search_form.html
@@ -7,7 +7,7 @@
       <div class="o-form__input-w-btn_input-container">
         <div class="m-btn-inside-input input-contains-label">
           <label for="query" class="input-contains-label_before input-contains-label_before__search">
-            {% include 'icons/magnifying-glass.svg' %}
+            {% include './icons/magnifying-glass.svg' %}
             <span class="u-visually-hidden">Search</span>
           </label>
           <input id="query" name="q" type="text" title="Search terms" class="a-text-input" value="{{ form.q }}" placeholder="Search terms">

--- a/viewer/viewer/templatetags/viewer.py
+++ b/viewer/viewer/templatetags/viewer.py
@@ -1,0 +1,14 @@
+import os.path
+
+from django import template
+
+from ..database import get_crawl_database_filename
+
+
+register = template.Library()
+
+
+@register.simple_tag()
+def get_database_file_size():
+    if filename := get_crawl_database_filename():
+        return os.path.getsize(filename)

--- a/viewer/viewer/urls.py
+++ b/viewer/viewer/urls.py
@@ -5,4 +5,9 @@ from . import views
 urlpatterns = [
     path("", views.PageListView.as_view(), name="index"),
     path("page/", views.PageDetailView.as_view(), name="page"),
+    path(
+        "download-database/",
+        views.DownloadDatabaseView.as_view(),
+        name="download-database"
+    ),
 ]

--- a/viewer/viewer/views.py
+++ b/viewer/viewer/views.py
@@ -1,15 +1,15 @@
 import re
 from urllib.parse import unquote
 
+from django.db import connections
 from django.db.models.expressions import RawSQL
-from django.http import Http404
+from django.http import FileResponse, Http404, HttpResponseNotFound
 from django.http.request import QueryDict
-from django.template.response import TemplateResponse
-from django.views.generic import DetailView, ListView
-from django.views.generic.edit import FormMixin
+from django.views.generic import DetailView, ListView, View
 
+from .database import get_crawl_database_filename
 from .forms import SearchForm
-from .models import Page, PageHTML
+from .models import Page
 
 
 class PageListView(ListView):
@@ -67,3 +67,11 @@ class PageDetailView(DetailView):
             return Page.objects.get(path=path)
         except Page.DoesNotExist:
             raise Http404(path)
+
+
+class DownloadDatabaseView(View):
+    def get(self, request, *args, **kwargs):
+        if filename := get_crawl_database_filename():
+            return FileResponse(open(filename, "rb"))
+
+        raise Http404


### PR DESCRIPTION
This commit adds a link to the page footer to download the SQLite database file. The link includes the size of the file to be downloaded, plus a link to instructions to query it in SQLite.

If there is no database file available to the app, the link is hidden.

Closes #11.

|Footer with database link|Footer without database link|
|-|-|
|<img width="1440" alt="image" src="https://user-images.githubusercontent.com/654645/172939589-ad9ffac0-0556-481c-9e7d-0e0f81232094.png">|<img width="1440" alt="image" src="https://user-images.githubusercontent.com/654645/172939682-cbb15098-e776-4c94-9e36-112771186f07.png">|
