### PR TITLE
Properly record components with underscores

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -44,7 +44,7 @@ class Parser {
   }
 
   getComponents () {
-    const SEARCH = /(?:(?:class=")|\s)((?:o|m|a)-[^_"__\s]*)/g;
+    const SEARCH = /(?:(?:class=")|\s)((?:o|m|a)-[^"\s]*)/g;
     const pageHMTL = this.html.toString();
     const prefixLookup = [
       'a-',


### PR DESCRIPTION
The crawler currently only saves components with dashes, but doesn't record those containing underscores. This commit fixes that.

Closes #19.