### PR TITLE
Hide CSV download link if there are no results

### DIFF
--- a/viewer/viewer/templates/viewer/page_list.html
+++ b/viewer/viewer/templates/viewer/page_list.html
@@ -16,7 +16,7 @@
       {% endif %}
     </h2>
   </div>
-  {% if total_count %}
+  {% if page_obj.paginator.count %}
   <div class="results_csv">
     <a class="a-link a-link__icon"
       href="{% url "download-csv" %}"


### PR DESCRIPTION
This commit hides the CSV download link if there are no results to show.

Closes #23.