### PR TITLE
Migrate to new data models and DRF-based views

### DIFF
--- a/viewer/requirements.txt
+++ b/viewer/requirements.txt
@@ -5,6 +5,7 @@ distlib==0.3.4
 Django==4.0.3
 django-click==2.3.0
 django-debug-toolbar==3.4.0
+django-filter==22.1
 django-modelcluster==6.0
 djangorestframework==3.13.1
 djangorestframework-csv==2.1.1

--- a/viewer/requirements.txt
+++ b/viewer/requirements.txt
@@ -6,6 +6,8 @@ Django==4.0.3
 django-click==2.3.0
 django-debug-toolbar==3.4.0
 django-modelcluster==6.0
+djangorestframework==3.13.1
+djangorestframework-csv==2.1.1
 filelock==3.7.1
 gunicorn==20.1.0
 humanize==4.1.0
@@ -19,6 +21,7 @@ six==1.16.0
 sqlparse==0.4.2
 toml==0.10.2
 tox==3.25.0
+unicodecsv==0.14.1
 virtualenv==20.14.1
 warcio==1.7.4
 whitenoise==6.1.0

--- a/viewer/settings.py
+++ b/viewer/settings.py
@@ -131,7 +131,7 @@ DEBUG_TOOLBAR_CONFIG = {
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [],
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "DEFAULT_PAGINATION_CLASS": "viewer.pagination.BetterPageNumberPagination",
     "DEFAULT_RENDERER_CLASSES": [
         "rest_framework.renderers.JSONRenderer",
         "rest_framework_csv.renderers.CSVStreamingRenderer",

--- a/viewer/settings.py
+++ b/viewer/settings.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
     "debug_toolbar",
     "django.contrib.humanize",
     "django.contrib.staticfiles",
+    "django_filters",
     "rest_framework",
     "viewer",
     "warc",
@@ -129,6 +130,7 @@ DEBUG_TOOLBAR_CONFIG = {
 # django-rest-framework
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [],
+    "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "DEFAULT_RENDERER_CLASSES": [
         "rest_framework.renderers.JSONRenderer",

--- a/viewer/settings.py
+++ b/viewer/settings.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
     "debug_toolbar",
     "django.contrib.humanize",
     "django.contrib.staticfiles",
+    "rest_framework",
     "viewer",
     "warc",
 ]
@@ -123,4 +124,17 @@ ALLOWED_HOSTS = ["*"]
 # django-debug-toolbar
 DEBUG_TOOLBAR_CONFIG = {
     "SHOW_COLLAPSED": True,
+}
+
+# django-rest-framework
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [],
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "DEFAULT_RENDERER_CLASSES": [
+        "rest_framework.renderers.JSONRenderer",
+        "rest_framework_csv.renderers.CSVStreamingRenderer",
+        "rest_framework.renderers.BrowsableAPIRenderer",
+    ],
+    "PAGE_SIZE": 25,
+    "UNAUTHENTICATED_USER": None,
 }

--- a/viewer/viewer/context_processors.py
+++ b/viewer/viewer/context_processors.py
@@ -3,14 +3,14 @@ import os
 from django.conf import settings
 from django.db.models import Count, Max, Min
 
-from .models import Page
+from warc.models import Page
 
 
 def crawl_stats(request):
-    crawl_stats = Page.objects.values("crawled_at").aggregate(
-        count=Count("crawled_at"),
-        start=Min("crawled_at"),
-        end=Max("crawled_at"),
+    crawl_stats = Page.objects.values("timestamp").aggregate(
+        count=Count("timestamp"),
+        start=Min("timestamp"),
+        end=Max("timestamp"),
     )
 
     crawl_stats.update(

--- a/viewer/viewer/forms.py
+++ b/viewer/viewer/forms.py
@@ -8,9 +8,10 @@ class SearchForm(forms.Form):
             (c, c)
             for c in (
                 "title",
-                "path",
+                "url",
                 "components",
                 "links",
+                "text",
                 "html",
             )
         ),

--- a/viewer/viewer/pagination.py
+++ b/viewer/viewer/pagination.py
@@ -1,0 +1,32 @@
+from re import M
+from rest_framework import pagination
+
+
+class BetterPageNumberPagination(pagination.PageNumberPagination):
+    """PageNumberPagination that includes page number information."""
+
+    def get_paginated_response(self, data):
+        response = super().get_paginated_response(data)
+        response.data.update(
+            {
+                "num_pages": self.page.paginator.num_pages,
+                "page_number": self.page.number,
+            }
+        )
+        return response
+
+    def get_paginated_response_schema(self, schema):
+        schema = super().get_paginated_response_schema(schema)
+        schema["properties"].update(
+            {
+                "num_pages": {
+                    "type": "integer",
+                    "example": 10,
+                },
+                "page_number": {
+                    "type": "integer",
+                    "example": 5,
+                },
+            }
+        )
+        return schema

--- a/viewer/viewer/renderers.py
+++ b/viewer/viewer/renderers.py
@@ -1,0 +1,14 @@
+from rest_framework.renderers import TemplateHTMLRenderer
+
+
+class BetterTemplateHTMLRenderer(TemplateHTMLRenderer):
+    """Properly handle non-paginated HTML results.
+
+    See https://github.com/encode/django-rest-framework/issues/5236#issuecomment-653451009.
+    """
+
+    def get_template_context(self, *args, **kwargs):
+        context = super().get_template_context(*args, **kwargs)
+        if isinstance(context, list):
+            context = {"results": context}
+        return context

--- a/viewer/viewer/serializers.py
+++ b/viewer/viewer/serializers.py
@@ -9,24 +9,52 @@ class ComponentSerializer(serializers.ModelSerializer):
         fields = ["class_name"]
 
 
-class RequestSerializer(serializers.ModelSerializer):
-    class Meta:
-        fields = ["timestamp", "url"]
+class RequestSerializer(serializers.Serializer):
+    timestamp = serializers.DateTimeField()
+    url = serializers.CharField()
 
 
 class PageSerializer(RequestSerializer):
+    title = serializers.CharField()
+    language = serializers.CharField()
+
+
+class PageWithComponentSerializer(PageSerializer):
+    class_name = serializers.CharField(source="components__class_name")
+
+
+class PageWithLinkSerializer(PageSerializer):
+    href = serializers.CharField(source="links__href")
+
+
+class PageDetailSerializer(serializers.ModelSerializer):
+    components = serializers.SlugRelatedField(
+        many=True, read_only=True, slug_field="class_name"
+    )
+
+    links = serializers.SlugRelatedField(many=True, read_only=True, slug_field="href")
+
     class Meta:
         model = Page
-        fields = RequestSerializer.Meta.fields + ["title", "language"]
+        fields = [
+            "timestamp",
+            "url",
+            "title",
+            "language",
+            "text",
+            "html",
+            "components",
+            "links",
+        ]
 
 
-class ErrorSerializer(RequestSerializer):
+class ErrorSerializer(serializers.ModelSerializer):
     class Meta:
         model = Error
-        fields = RequestSerializer.Meta.fields + ["status_code", "referrer"]
+        fields = ["timestamp", "url", "status_code", "referrer"]
 
 
-class RedirectSerializer(ErrorSerializer):
+class RedirectSerializer(serializers.ModelSerializer):
     class Meta:
         model = Redirect
-        fields = ErrorSerializer.Meta.fields + ["location"]
+        fields = ["timestamp", "url", "status_code", "referrer", "location"]

--- a/viewer/viewer/serializers.py
+++ b/viewer/viewer/serializers.py
@@ -1,0 +1,32 @@
+from rest_framework import serializers
+
+from warc.models import Component, Error, Page, Redirect
+
+
+class ComponentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Component
+        fields = ["class_name"]
+
+
+class RequestSerializer(serializers.ModelSerializer):
+    class Meta:
+        fields = ["timestamp", "url"]
+
+
+class PageSerializer(RequestSerializer):
+    class Meta:
+        model = Page
+        fields = RequestSerializer.Meta.fields + ["title", "language"]
+
+
+class ErrorSerializer(RequestSerializer):
+    class Meta:
+        model = Error
+        fields = RequestSerializer.Meta.fields + ["status_code", "referrer"]
+
+
+class RedirectSerializer(ErrorSerializer):
+    class Meta:
+        model = Redirect
+        fields = ErrorSerializer.Meta.fields + ["location"]

--- a/viewer/viewer/templates/viewer/component_list.html
+++ b/viewer/viewer/templates/viewer/component_list.html
@@ -4,23 +4,23 @@
 
 {% block intro %}
 <div class="lead-paragraph">
-  {{ components.count | intcomma }} total
+  {{ results | length | intcomma }} total
   <a class="a-link a-link__icon"
     href="https://cfpb.github.io/design-system"
   >
     <span class="a-link_text">CFPB Design System</span>
     <svg class="cf-icon-svg" viewBox="0 0 14 19" xmlns="http://www.w3.org/2000/svg"><path d="M13.017 3.622v4.6a.554.554 0 0 1-1.108 0V4.96L9.747 7.122a1.65 1.65 0 0 1 .13.646v5.57A1.664 1.664 0 0 1 8.215 15h-5.57a1.664 1.664 0 0 1-1.662-1.663v-5.57a1.664 1.664 0 0 1 1.662-1.662h5.57A1.654 1.654 0 0 1 9 6.302l2.126-2.126H7.863a.554.554 0 1 1 0-1.108h4.6a.554.554 0 0 1 .554.554zM8.77 8.1l-2.844 2.844a.554.554 0 0 1-.784-.783l2.947-2.948H2.645a.555.555 0 0 0-.554.555v5.57a.555.555 0 0 0 .554.553h5.57a.555.555 0 0 0 .554-.554z"></path></svg>
   </a>
-  component{{ components.count | pluralize }}
+  component{{ results | length | pluralize }}
 </div>
 {% endblock %}
 
 {% block content %}
 <div class="results_list">
   <ul class="m-list">
-    {% for component in components %}
+    {% for component in results %}
     <li class="results_item">
-      <a href="{% url "index" %}?search_type=components&q={{ component.name | escape }}">{{ component.name }}</a>
+      <a href="{% url "index" %}?search_type=components&q={{ component.class_name | escape }}">{{ component.class_name }}</a>
     </li>
     {% endfor %}
   </ul>

--- a/viewer/viewer/templates/viewer/page_detail.html
+++ b/viewer/viewer/templates/viewer/page_detail.html
@@ -1,5 +1,7 @@
 {% extends './base.html' %}
 
+{% load page_display %}
+
 {% block content %}
   <div class="content_wrapper search_results">
     <div class="block block__flush-top">
@@ -12,10 +14,10 @@
             </a>
           </nav>
           <div class="block block__flush-bottom">
-            <h2>Page: {{ page.get_trimmed_page_title }}</h2>
+            <h2>Page: {{ title | strip_title_suffix }}</h2>
           </div>
           <div class="block block__flush-top">
-            <a href="{{ page.absolute_path }}">{{ page.absolute_path }}</a> (last crawled {{ page.crawled_at }})
+            <a href="{{ url }}">{{ url }}</a> (last crawled {{ timestamp }})
           </div>
           <div class="o-expandable o-expandable__padded o-expandable__background o-expandable__border u-mb20">
             <button class="o-expandable_header o-expandable_target" title="Expand content">
@@ -35,8 +37,8 @@
             </button>
             <div class="o-expandable_content o-expandable_content__onload-open">
               <ul class="m-list">
-                {% for link in page.links.all %}
-                  <li class="m-list_item u-truncate">{{ link.url }}</li>
+                {% for link in links %}
+                  <li class="m-list_item u-truncate">{{ link }}</li>
                 {% endfor %}
               </ul>
             </div>
@@ -59,10 +61,30 @@
             </button>
             <div class="o-expandable_content">
               <ul class="m-list">
-                {% for component in page.components.all %}
-                  <li class="m-list_item">{{ component.name }}</li>
+                {% for component in components %}
+                  <li class="m-list_item">{{ component }}</li>
                 {% endfor %}
               </ul>
+            </div>
+          </div>
+          <div class="o-expandable o-expandable__padded o-expandable__background o-expandable__border u-mb20">
+            <button class="o-expandable_header o-expandable_target" title="Expand content">
+              <h3 class="h4 o-expandable_header-left o-expandable_label">
+                Text
+              </h3>
+              <span class="o-expandable_header-right o-expandable_link">
+                <span class="o-expandable_cue o-expandable_cue-open">
+                  <span class="u-visually-hidden-on-mobile">Show</span>
+                  {% include './icons/plus-round.svg' %}
+                </span>
+                <span class="o-expandable_cue o-expandable_cue-close">
+                  <span class="u-visually-hidden-on-mobile">Hide</span>
+                  {% include './icons/minus-round.svg' %}
+                </span>
+              </span>
+            </button>
+            <div class="o-expandable_content">
+              <pre>{{ text }}</pre>
             </div>
           </div>
           <div class="o-expandable o-expandable__padded o-expandable__background o-expandable__border u-mb20">
@@ -82,7 +104,7 @@
               </span>
             </button>
             <div class="o-expandable_content">
-              <pre><code class="language-html">{{ page.html }}</code></pre>
+              <pre><code class="language-html">{{ html }}</code></pre>
             </div>
           </div>
         </section>

--- a/viewer/viewer/templates/viewer/page_list.html
+++ b/viewer/viewer/templates/viewer/page_list.html
@@ -1,32 +1,33 @@
 {% extends './base_search.html' %}
 
 {% load humanize %}
+{% load page_display %}
 
 {% block content_main %}
 <div class="results_header">
   <div class="results_count">
     <h2 class="h3">
-      {% if page_obj.paginator.count == crawl_stats.count %}
+      {% if count == crawl_stats.count %}
       Showing {{ crawl_stats.count | intcomma }}
       total page{{ crawl_stats.count | pluralize }}
       {% else %}
-      Showing {{ page_obj.paginator.count | intcomma }}
-      match{{ page_obj.paginator.count | pluralize:"es" }}
+      Showing {{ count | intcomma }}
+      match{{ count | pluralize:"es" }}
       out of {{ crawl_stats.count | intcomma }} total pages
       {% endif %}
     </h2>
   </div>
-  {% if page_obj.paginator.count %}
+  {% if count %}
   <div class="results_csv">
     <a class="a-link a-link__icon"
-      href="{% url "download-csv" %}"
+      href="{% url "index" %}?format=csv{% if request.query_params.search_type %}&search_type={{ request.query_params.search_type | urlencode }}{% endif %}{% if request.query_params.q %}&q={{ request.query_params.q | urlencode }}{% endif %}"
     >
       <span class="a-link_text">Download CSV file</span>
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 19" class="cf-icon-svg"><path d="M11.16 16.153a.477.477 0 0 1-.476.475H1.316a.476.476 0 0 1-.475-.475V3.046a.476.476 0 0 1 .475-.475h6.95l2.893 2.893zm-1.11-9.925H8.059a.575.575 0 0 1-.574-.573V3.679H1.95v11.84h8.102zm-1.234 5.604L6.388 14.26a.554.554 0 0 1-.784 0l-2.428-2.428a.554.554 0 1 1 .783-.784l1.483 1.482V7.41a.554.554 0 1 1 1.108 0v5.12l1.482-1.482a.554.554 0 0 1 .784.783z"></path></svg>
     </a>
     {# Use an arbitrary estimate of how big the CSV is likely to be. #}
     {# Use Django's built-in width ratio tag as a way to multiply. #}
-    {% widthratio page_obj.paginator.count 1 256 as csv_file_size %}
+    {% widthratio count 1 256 as csv_file_size %}
     (~{{ csv_file_size | filesizeformat }})
   </div>
   {% endif %}
@@ -34,30 +35,32 @@
 
 <div class="results_list">
   <ul class="m-list">
-    {% for page in pages %}
+    {% for page in results %}
     <li class="results_item">
       <h4>
-        <a class="a-link  a-link__icon"
-          href="{{ page.absolute_path }}"
+        <a class="a-link a-link__icon"
+          href="{{ page.url }}"
         >
-          <span class="a-link_text u-truncate">{{ page.get_trimmed_page_title }}</span>
+          <span class="a-link_text u-truncate">
+            {{ page.title | strip_title_suffix }}
+          </span>
           <svg class="cf-icon-svg" viewBox="0 0 14 19" xmlns="http://www.w3.org/2000/svg"><path d="M13.017 3.622v4.6a.554.554 0 0 1-1.108 0V4.96L9.747 7.122a1.65 1.65 0 0 1 .13.646v5.57A1.664 1.664 0 0 1 8.215 15h-5.57a1.664 1.664 0 0 1-1.662-1.663v-5.57a1.664 1.664 0 0 1 1.662-1.662h5.57A1.654 1.654 0 0 1 9 6.302l2.126-2.126H7.863a.554.554 0 1 1 0-1.108h4.6a.554.554 0 0 1 .554.554zM8.77 8.1l-2.844 2.844a.554.554 0 0 1-.784-.783l2.947-2.948H2.645a.555.555 0 0 0-.554.555v5.57a.555.555 0 0 0 .554.553h5.57a.555.555 0 0 0 .554-.554z"></path></svg>
         </a>
 
-        <small>(<a href="{{ page.get_absolute_url }}">details</a>)</small>
+        <small>(<a href="{% url 'page' %}?url={{ page.url | urlencode }}">details</a>)</small>
       </h4>
 
-      <div class="u-truncate">{{ page.path }}</div>
+      <div class="u-truncate">{{ page.url }}</div>
     </li>
     {% endfor %}
   </ul>
 </div>
 
-{% if page_obj.paginator.num_pages > 1 %}
+{% if previous or next %}
 <div class="results_paginator">
   <nav class="m-pagination" role="navigation" aria-label="Pagination">
-    {% if page_obj.has_previous %}
-    <a class="a-btn m-pagination_btn-prev" href="?page={{ page_obj.previous_page_number }}{% if pagination_query_params %}&amp;{{ pagination_query_params }}{% endif %}">
+    {% if previous %}
+    <a class="a-btn m-pagination_btn-prev" href="{{ previous }}">
       {% else %}
       <a class="a-btn
                   a-btn__disabled
@@ -68,8 +71,8 @@
         </span>
         Previous
       </a>
-      {% if page_obj.has_next %}
-      <a class="a-btn m-pagination_btn-next" href="?page={{ page_obj.next_page_number }}{% if pagination_query_params %}&amp;{{ pagination_query_params }}{% endif %}">
+      {% if next %}
+      <a class="a-btn m-pagination_btn-next" href="{{ next }}">
         {% else %}
         <a class="a-btn
                 a-btn__disabled
@@ -80,13 +83,13 @@
             {% include './icons/chevron-right.svg' %}
           </span>
         </a>
-        <form class="m-pagination_form" action="{% if pagination_query_params %}?{{ pagination_query_params }}{% endif %}">
+        <form class="m-pagination_form" action="{% url 'index' %}">
           <label for="m-pagination_current-page">
             <span class="m-pagination_label">
               Page
             </span>
             <span class="u-visually-hidden">
-              {{ page_obj.number }} out of {{ page_obj.paginator.num_pages }} total pages
+              {{ page_obj.number }} out of {{ num_pages }} total pages
             </span>
           </label>
           <input id="m-pagination_current-page"
@@ -94,20 +97,20 @@
                  name="page"
                  type="number"
                  min="1"
-                 max="{{ page_obj.paginator.num_pages }}"
+                 max="{{ num_pages }}"
                  pattern="[0-9]*"
                  inputmode="numeric"
-                 value="{{ page_obj.number }}">
+                 value="{{ page_number }}">
           <span class="m-pagination_label">
-            of {% widthratio page_obj.paginator.count page_obj.paginator.per_page 1 %}
+            of {{ num_pages }}
           </span>
           <button class="a-btn
                         a-btn__link
                         m-pagination_btn-submit" type="submit">
             Go
           </button>
-          <input type="hidden" name="search_type" value="{{ form.search_type }}">
-          <input type="hidden" name="q" value="{{ form.q }}">
+          <input type="hidden" name="search_type" value="{{ request.query_params.search_type }}">
+          <input type="hidden" name="q" value="{{ request.query_params.q }}">
         </form>
   </nav>
 </div>

--- a/viewer/viewer/templates/viewer/search_form.html
+++ b/viewer/viewer/templates/viewer/search_form.html
@@ -1,6 +1,6 @@
 <div class="search_wrapper u-mt30">
   <form action="{% url 'index' %}" id="search_form">
-    <input type="hidden" name="search_type" value="{{ form.search_type | default:'title' }}">
+    <input type="hidden" name="search_type" value="{{ request.query_params.search_type | default:'title' }}">
     <h2 class="h4">Search terms</h2>
     <div class="o-form__input-w-btn">
       <div class="o-form__input-w-btn_input-container">
@@ -9,7 +9,7 @@
             {% include './icons/magnifying-glass.svg' %}
             <span class="u-visually-hidden">Search</span>
           </label>
-          <input id="query" name="q" type="text" title="Search terms" class="a-text-input" value="{{ form.q }}" placeholder="Search terms">
+          <input id="query" name="q" type="text" title="Search terms" class="a-text-input" value="{{ request.query_params.q.strip }}" placeholder="Search terms">
         </div>
       </div>
       <div class="o-form__input-w-btn_btn-container">

--- a/viewer/viewer/templates/viewer/search_side_bar.html
+++ b/viewer/viewer/templates/viewer/search_side_bar.html
@@ -1,29 +1,33 @@
 
     <h3>Refine results</h3>
     <form action="{% url 'index' %}" method="get">
-      <input type="hidden" name="q" value="{{ form.q }}">
+      <input type="hidden" name="q" value="{{ request.query_params.q }}">
       <div>
         <div class="o-form_group u-mb30">
           <fieldset class="o-form_fieldset">
             <legend class="h4">Things to search for</legend>
             <div class="m-form-field m-form-field__radio reg-radio">
-              <input class="a-radio" type="radio" value="title" id="search_type_title" name="search_type"{% if form.search_type is None or form.search_type == 'title' %} checked{% endif %}>
+              <input class="a-radio" type="radio" value="title" id="search_type_title" name="search_type"{% if request.query_params.search_type is None or request.query_params.search_type == 'title' %} checked{% endif %}>
               <label class="a-label" for="search_type_title">Title</label>
             </div>
             <div class="m-form-field m-form-field__radio reg-radio">
-              <input class="a-radio" type="radio" value="path" id="search_type_path" name="search_type"{% if form.search_type == 'path' %} checked{% endif %}>
-              <label class="a-label" for="search_type_path">URL</label>
+              <input class="a-radio" type="radio" value="url" id="search_type_url" name="search_type"{% if request.query_params.search_type == 'url' %} checked{% endif %}>
+              <label class="a-label" for="search_type_url">URL</label>
             </div>
             <div class="m-form-field m-form-field__radio reg-radio">
-              <input class="a-radio" type="radio" value="components" id="search_type_components" name="search_type"{% if form.search_type == 'components' %} checked{% endif %}>
+              <input class="a-radio" type="radio" value="components" id="search_type_components" name="search_type"{% if request.query_params.search_type == 'components' %} checked{% endif %}>
               <label class="a-label" for="search_type_components">Components</label>
             </div>
             <div class="m-form-field m-form-field__radio reg-radio">
-              <input class="a-radio" type="radio" value="links" id="search_type_links" name="search_type"{% if form.search_type == 'links' %} checked{% endif %}>
+              <input class="a-radio" type="radio" value="links" id="search_type_links" name="search_type"{% if request.query_params.search_type == 'links' %} checked{% endif %}>
               <label class="a-label" for="search_type_links">Links</label>
             </div>
             <div class="m-form-field m-form-field__radio reg-radio">
-              <input class="a-radio" type="radio" value="html" id="search_type_html" name="search_type"{% if form.search_type == 'html' %} checked{% endif %}>
+              <input class="a-radio" type="radio" value="text" id="search_type_text" name="search_type"{% if request.query_params.search_type == 'text' %} checked{% endif %}>
+              <label class="a-label" for="search_type_text">Text</label>
+            </div>
+            <div class="m-form-field m-form-field__radio reg-radio">
+              <input class="a-radio" type="radio" value="html" id="search_type_html" name="search_type"{% if request.query_params.search_type == 'html' %} checked{% endif %}>
               <label class="a-label" for="search_type_html">HTML</label>
             </div>
           </fieldset>

--- a/viewer/viewer/templatetags/page_display.py
+++ b/viewer/viewer/templatetags/page_display.py
@@ -1,0 +1,19 @@
+import re
+
+from django import template
+
+
+register = template.Library()
+
+
+PAGE_TITLE_SUFFIX_RE = re.compile(
+    r" \| ("
+    r"Consumer Financial Protection Bureau|"
+    r"Oficina para la Protección Financiera del Consumidor"
+    r")$"
+)
+
+
+@register.filter
+def strip_title_suffix(title):
+    return PAGE_TITLE_SUFFIX_RE.sub("", title)

--- a/viewer/viewer/urls.py
+++ b/viewer/viewer/urls.py
@@ -1,6 +1,15 @@
-from django.urls import path
+from django.urls import include, path
 
-from . import views
+from rest_framework import routers
+
+from viewer import views
+
+
+router = routers.DefaultRouter()
+router.register(r"components", views.ComponentViewSet)
+router.register(r"errors", views.ErrorViewSet)
+router.register(r"pages", views.PageViewSet)
+router.register(r"redirects", views.RedirectViewSet)
 
 
 urlpatterns = [
@@ -13,4 +22,5 @@ urlpatterns = [
         name="download-database",
     ),
     path("components", views.ComponentsListView.as_view(), name="components"),
+    path("api/", include(router.urls)),
 ]

--- a/viewer/viewer/urls.py
+++ b/viewer/viewer/urls.py
@@ -1,25 +1,17 @@
-from django.urls import include, path
-
-from rest_framework import routers
+from django.urls import path
 
 from viewer import views
-
-
-router = routers.DefaultRouter()
-router.register(r"errors", views.ErrorViewSet)
-router.register(r"pages", views.PageViewSet)
-router.register(r"redirects", views.RedirectViewSet)
 
 
 urlpatterns = [
     path("", views.PageListView.as_view(), name="index"),
     path("page/", views.PageDetailView.as_view(), name="page"),
-    path("download-csv/", views.DownloadCSVView.as_view(), name="download-csv"),
+    path("components/", views.ComponentListView.as_view(), name="components"),
+    path("errors/", views.ErrorListView.as_view(), name="errors"),
+    path("redirects/", views.RedirectListView.as_view(), name="redirects"),
     path(
         "download-database/",
         views.DownloadDatabaseView.as_view(),
         name="download-database",
     ),
-    path("components/", views.ComponentsListView.as_view(), name="components"),
-    path("api/", include(router.urls)),
 ]

--- a/viewer/viewer/urls.py
+++ b/viewer/viewer/urls.py
@@ -6,7 +6,6 @@ from viewer import views
 
 
 router = routers.DefaultRouter()
-router.register(r"components", views.ComponentViewSet)
 router.register(r"errors", views.ErrorViewSet)
 router.register(r"pages", views.PageViewSet)
 router.register(r"redirects", views.RedirectViewSet)
@@ -21,6 +20,6 @@ urlpatterns = [
         views.DownloadDatabaseView.as_view(),
         name="download-database",
     ),
-    path("components", views.ComponentsListView.as_view(), name="components"),
+    path("components/", views.ComponentsListView.as_view(), name="components"),
     path("api/", include(router.urls)),
 ]

--- a/viewer/viewer/views.py
+++ b/viewer/viewer/views.py
@@ -1,140 +1,41 @@
-import codecs
-import csv
-
 from django.conf import settings
-from django.db.models import CharField, Exists, ExpressionWrapper, F, Func, OuterRef
-from django.http import FileResponse, Http404, StreamingHttpResponse
-from django.http.request import QueryDict
-from django.views.generic import DetailView, ListView, View
+from django.http import FileResponse
+from django.shortcuts import get_object_or_404
+from django.views.generic import View
 
-from rest_framework.generics import ListAPIView
-from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework.generics import ListAPIView, RetrieveAPIView
 
 from viewer.forms import SearchForm
-from viewer.models import Page
 from viewer.renderers import BetterTemplateHTMLRenderer
 from viewer.serializers import (
     ComponentSerializer,
     ErrorSerializer,
     PageSerializer,
+    PageDetailSerializer,
+    PageWithComponentSerializer,
+    PageWithLinkSerializer,
     RedirectSerializer,
 )
-from warc.models import Component, Error, Page as WarcPage, Redirect
-
-
-class PageListView(ListView):
-    model = Page
-    context_object_name = "pages"
-    paginate_by = 25
-
-    def get_context_data(self, *args, **kwargs):
-        qs = self.object_list
-        pagination_query_params = QueryDict({}, mutable=True)
-
-        form = SearchForm(self.request.GET)
-        if form.is_valid():
-            q = form.cleaned_data.get("q")
-            search_type = form.cleaned_data.get("search_type")
-            pagination_query_params["q"] = q
-
-            if q:
-                pagination_query_params["search_type"] = search_type
-
-                if "title" == search_type:
-                    qs = qs.filter(title__icontains=q).order_by("title")
-                    ordering = "title"
-                elif "path" == search_type:
-                    qs = qs.filter(path__icontains=q)
-                elif "components" == search_type:
-                    # This is significantly faster than the simpler
-                    # qs = qs.filter(components__name__icontains=q)
-                    qs = qs.filter(
-                        Exists(
-                            Page.components.through.objects.filter(
-                                page=OuterRef("id"), component__name__icontains=q
-                            )
-                        )
-                    )
-                elif "links" == search_type:
-                    # This is significantly faster than the simpler
-                    # qs = qs.filter(links__url_icontains=q)
-                    qs = qs.filter(
-                        Exists(
-                            Page.links.through.objects.filter(
-                                page=OuterRef("id"), link__url__icontains=q
-                            )
-                        )
-                    )
-                elif "html" == search_type:
-                    qs = qs.filter(html__icontains=q)
-
-        qs = qs.only("path", "title")
-
-        return super().get_context_data(
-            object_list=qs,
-            form=form.cleaned_data,
-            pagination_query_params=pagination_query_params.urlencode(),
-        )
-
-
-class DownloadCSVView(PageListView):
-    def render_to_response(self, context, **response_kwargs):
-        return StreamingHttpResponse(
-            self.generate_csv_content(context),
-            content_type="text/csv",
-            headers={
-                "Content-Disposition": 'attachment; filename="export.csv"',
-            },
-        )
-
-    def generate_csv_content(self, context):
-        columns = (
-            "path",
-            "title",
-            "crawled_at",
-            "hash",
-        )
-
-        # Inspired by https://docs.djangoproject.com/en/4.0/howto/outputting-csv/#streaming-large-csv-files.
-        class Echo:
-            def write(self, value):
-                return value
-
-        buffer = Echo()
-        yield buffer.write(codecs.BOM_UTF8)  # u'\ufeff'.encode('utf8'))
-
-        writer = csv.writer(buffer)
-
-        yield writer.writerow(columns)
-
-        pages = context["pages"].annotate(
-            crawled=ExpressionWrapper(
-                Func(F("timestamp"), function="DATETIME"), output_field=CharField()
-            )
-        )
-
-        for page in pages.iterator():
-            yield writer.writerow(getattr(page, col) for col in columns)
-
-
-class PageDetailView(DetailView):
-    model = Page
-
-    def get_object(self, queryset=None):
-        path = self.request.GET.get("path")
-
-        if not path:
-            raise Http404("Missing path parameter")
-
-        try:
-            return Page.objects.get(path=path)
-        except Page.DoesNotExist:
-            raise Http404(path)
+from warc.models import Component, Error, Page, Redirect
+from warc.search import (
+    search_components,
+    search_html,
+    search_links,
+    search_text,
+    search_title,
+    search_url,
+)
 
 
 class DownloadDatabaseView(View):
     def get(self, request, *args, **kwargs):
         return FileResponse(open(settings.CRAWL_DATABASE, "rb"))
+
+
+class AlsoRenderHTMLMixin:
+    @property
+    def renderer_classes(self):
+        return [BetterTemplateHTMLRenderer] + super().renderer_classes
 
 
 class BetterCSVsMixin:
@@ -157,31 +58,7 @@ class BetterCSVsMixin:
         return context
 
 
-class AlsoRenderHTMLMixin:
-    @property
-    def renderer_classes(self):
-        return [BetterTemplateHTMLRenderer] + super().renderer_classes
-
-
-class BetterCSVsReadOnlyModelViewSet(BetterCSVsMixin, ReadOnlyModelViewSet):
-    pass
-
-
-class BetterCSVsAndHTMLReadOnlyModelViewSet(
-    AlsoRenderHTMLMixin, BetterCSVsReadOnlyModelViewSet
-):
-    pass
-
-
-class BetterCSVsListAPIView(BetterCSVsMixin, ListAPIView):
-    pass
-
-
-class BetterCSVsAndHTMLListApiView(AlsoRenderHTMLMixin, BetterCSVsListAPIView):
-    pass
-
-
-class ComponentsListView(BetterCSVsAndHTMLListApiView):
+class ComponentListView(AlsoRenderHTMLMixin, BetterCSVsMixin, ListAPIView):
     queryset = Component.objects.all()
     serializer_class = ComponentSerializer
     pagination_class = None
@@ -190,20 +67,65 @@ class ComponentsListView(BetterCSVsAndHTMLListApiView):
         return ["viewer/component_list.html"]
 
 
-class ErrorViewSet(BetterCSVsReadOnlyModelViewSet):
+class ErrorListView(BetterCSVsMixin, ListAPIView):
     queryset = Error.objects.all()
     serializer_class = ErrorSerializer
     filterset_fields = ["status_code"]
 
 
-class RedirectViewSet(BetterCSVsReadOnlyModelViewSet):
+class RedirectListView(BetterCSVsMixin, ListAPIView):
     queryset = Redirect.objects.all()
     serializer_class = RedirectSerializer
     filterset_fields = ["status_code"]
 
 
-class PageViewSet(BetterCSVsReadOnlyModelViewSet):
-    queryset = WarcPage.objects.all()
-    serializer_class = PageSerializer
+class PageMixin(AlsoRenderHTMLMixin, BetterCSVsMixin):
     filterset_fields = ["language"]
-    lookup_field = "url"
+
+    def get_queryset(self):
+        form = SearchForm(self.request.query_params)
+        if form.is_valid():
+            q = form.cleaned_data["q"]
+            search_type = form.cleaned_data["search_type"]
+
+            if "components" == search_type:
+                return search_components(q, include_class_names=self.is_rendering_csv)
+            elif "html" == search_type:
+                return search_html(q)
+            elif "links" == search_type:
+                return search_links(q, include_hrefs=self.is_rendering_csv)
+            elif "text" == search_type:
+                return search_text(q)
+            elif "title" == search_type:
+                return search_title(q)
+            elif "url" == search_type:
+                return search_url(q)
+
+        return Page.objects.all()
+
+
+class PageListView(PageMixin, ListAPIView):
+    def get_template_names(self):
+        return ["viewer/page_list.html"]
+
+    def get_serializer_class(self):
+        if self.is_rendering_csv:
+            search_type = self.request.query_params.get("search_type")
+
+            if search_type == "components":
+                return PageWithComponentSerializer
+            elif search_type == "links":
+                return PageWithLinkSerializer
+
+        return PageSerializer
+
+
+class PageDetailView(PageMixin, RetrieveAPIView):
+    serializer_class = PageDetailSerializer
+
+    def get_object(self):
+        queryset = Page.objects.all().prefetch_related("components", "links")
+        return get_object_or_404(queryset, url=self.request.query_params.get("url"))
+
+    def get_template_names(self):
+        return ["viewer/page_detail.html"]

--- a/viewer/viewer/views.py
+++ b/viewer/viewer/views.py
@@ -169,13 +169,16 @@ class ComponentViewSet(ReadOnlyModelViewSetSpecialCSVHandling):
 class ErrorViewSet(ReadOnlyModelViewSetSpecialCSVHandling):
     queryset = Error.objects.all()
     serializer_class = ErrorSerializer
+    filterset_fields = ["status_code"]
 
 
 class RedirectViewSet(ReadOnlyModelViewSetSpecialCSVHandling):
     queryset = Redirect.objects.all()
     serializer_class = RedirectSerializer
+    filterset_fields = ["status_code"]
 
 
 class PageViewSet(ReadOnlyModelViewSetSpecialCSVHandling):
     queryset = WarcPage.objects.all()
     serializer_class = PageSerializer
+    filterset_fields = ["language"]

--- a/viewer/warc/models.py
+++ b/viewer/warc/models.py
@@ -10,14 +10,21 @@ class Request(models.Model):
 
     class Meta:
         abstract = True
+        ordering = ["url"]
 
 
 class Component(models.Model):
     class_name = models.TextField(unique=True, db_index=True)
 
+    class Meta:
+        ordering = ["class_name"]
+
 
 class Link(models.Model):
     href = models.TextField(unique=True, db_index=True)
+
+    class Meta:
+        ordering = ["href"]
 
 
 class Page(Request, ClusterableModel):
@@ -33,8 +40,9 @@ class ErrorBase(Request):
     status_code = models.PositiveIntegerField(db_index=True)
     referrer = models.TextField(db_index=True, null=True, blank=True)
 
-    class Meta:
+    class Meta(Request.Meta):
         abstract = True
+
 
 
 class Error(ErrorBase):

--- a/viewer/warc/models.py
+++ b/viewer/warc/models.py
@@ -44,7 +44,6 @@ class ErrorBase(Request):
         abstract = True
 
 
-
 class Error(ErrorBase):
     pass
 

--- a/viewer/warc/search.py
+++ b/viewer/warc/search.py
@@ -1,0 +1,50 @@
+from warc.models import Page
+
+
+_page_values = ["timestamp", "url", "title", "language"]
+
+
+def search_components(class_name_contains, include_class_names=False):
+    values = _page_values
+
+    if include_class_names:
+        values = values + ["components__class_name"]
+
+    return (
+        Page.objects.prefetch_related("components")
+        .filter(components__class_name__contains=class_name_contains)
+        .values(*values)
+    )
+
+
+def search_links(href_contains, include_hrefs=False):
+    values = _page_values
+
+    if include_hrefs:
+        values = values + ["links__href"]
+
+    return (
+        Page.objects.prefetch_related("links")
+        .filter(links__href__contains=href_contains)
+        .values(*values)
+    )
+
+
+def _search_pages(**filter_kwargs):
+    return Page.objects.filter(**filter_kwargs).values(*_page_values)
+
+
+def search_html(html_contains):
+    return _search_pages(html__contains=html_contains)
+
+
+def search_text(text_contains):
+    return _search_pages(text__contains=text_contains)
+
+
+def search_title(title_contains):
+    return _search_pages(title__contains=title_contains)
+
+
+def search_url(url_contains):
+    return _search_pages(url__contains=url_contains)


### PR DESCRIPTION
This PR makes significant changes to the way the viewer gets its data and renders its views:

- All data models now live in the `warc` app and are assumed to have been loaded from a WARC archive via `manage.py warc_to_db`. The former Node-based crawler approach is now deprecated; that code needs to be removed from this repository.
- Almost all views are now rendered by django-rest-framework, which allows for debugging of data via JSON, CSV, and interactive DRF API views.

Testing:

- Run a local server with a WARC-based database: `CRAWL_DATABASE=./crawl.sqlite3 viewer/manage.py runserver`
- Homepage reflects the full dataset: http://localhost:8000/
   - clicking "Download CSV file" downloads a large CSV with one row per URL, including language: http://localhost:8000/?format=csv
   - manually editing the URL to http://localhost:8000/?format=api shows the DRF paginated API
   - http://localhost:8000/?format=json allows for browsing via JSON
- "design components" link lists all crawled components: http://localhost:8000/components/
   - each one links to a component search: http://localhost:8000/?search_type=components&q=a-btn
   - clicking "Download CSV file" downloads a CSV with individual rows for (url, component) unique pairs: http://localhost:8000/?format=csv&search_type=components&q=a-btn
 - Searching by "Links" works properly: http://localhost:8000/?search_type=links&q=chopra
   - clicking "Download CSV file" downloads a CSV with individual rows for (url, link href) unique pairs: http://localhost:8000/?format=csv&search_type=links&q=chopra
 - Searching by "Text" works properly: http://localhost:8000/?search_type=text&q=medical+debt

Other changes:

- Crawl errors (404s, 403s, 500s) can now be viewed in a paginated way via the DRF interface, including referrers: http://localhost:8000/errors/
   - The full list can also be downloaded as CSV: http://localhost:8000/errors/?format=csv
- Crawl redirects can similarly be viewed, also including referrers: http://localhost:8000/redirects/
   - And downloaded as CSV: http://localhost:8000/redirects/?format=csv
- Page detail view now includes text content of the page as another expandable: http://localhost:8000/page/?url=http%3A//www.consumerfinance.gov/about-us/blog/a-closer-look-at-the-trillion/
   - Page detail view can also be retrieved as JSON: http://localhost:8000/page/?url=http%3A//www.consumerfinance.gov/about-us/blog/a-closer-look-at-the-trillion/&format=json

TODOs:

- The README and related documentation needs to be updated to reflect these changes.
- The sample database included when running this app without a real crawl result needs to be replaced with one generated with the new database schema.