### PR TITLE
Prototype help / common searches page

### DIFF
--- a/viewer/viewer/templates/viewer/base.html
+++ b/viewer/viewer/templates/viewer/base.html
@@ -8,7 +8,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-    <title>{% block title %}Crawsqueal{% endblock %}</title>
+    <title>{% block title %}Consumerfinance.gov crawler{% endblock %}</title>
     <link rel="stylesheet" href="{% static "main.css" %}">
     <link rel="stylesheet" href="{% static "crawsqueal.css" %}">
   </head>
@@ -56,17 +56,6 @@
       <div class="wrapper content_wrapper">
         <div class="content_main content__1-3">
           <div class="content_main-inner">
-            <div class="block block__sub">
-              <div class="content_wrapper search_form">
-                <h1>Consumerfinance.gov <span class="search_intro__all">crawler</span></h1>
-                  {% block intro %}
-                  <div class="lead-paragraph">
-                    Here's a brief description of what it does. Check out
-                    <a href="{% url "components" %}">common searches.</a>
-                  </div>
-                  {% endblock intro %}
-              </div>
-            </div>
             {% block content %}{% endblock content %}
           </div>
         </div>

--- a/viewer/viewer/templates/viewer/base_search.html
+++ b/viewer/viewer/templates/viewer/base_search.html
@@ -1,6 +1,18 @@
 {% extends './base.html' %}
 
 {% block content %}
+  <div class="block block__sub">
+    <div class="content_wrapper search_form">
+      <h1>Consumerfinance.gov crawler</h1>
+        {% block intro %}
+        <div class="lead-paragraph">
+          The crawler stores a nightly snapshot of webpage data that you can search for all sorts of useful things.
+          Check out <a href="{% url 'help' %}">common searches</a>.
+        </div>
+        {% endblock intro %}
+    </div>
+  </div>
+
   <div class="content_wrapper search_form">
     {% include './search_form.html' %}
   </div>

--- a/viewer/viewer/templates/viewer/component_list.html
+++ b/viewer/viewer/templates/viewer/component_list.html
@@ -2,7 +2,7 @@
 
 {% load humanize %}
 
-{% block intro %}
+{% block content %}
 <div class="lead-paragraph">
   {{ results | length | intcomma }} total
   <a class="a-link a-link__icon"
@@ -13,9 +13,7 @@
   </a>
   component{{ results | length | pluralize }}
 </div>
-{% endblock %}
 
-{% block content %}
 <div class="results_list">
   <ul class="m-list">
     {% for component in results %}

--- a/viewer/viewer/templates/viewer/help.html
+++ b/viewer/viewer/templates/viewer/help.html
@@ -1,0 +1,122 @@
+{% extends './base.html' %}
+
+{% block content %}
+<nav class="breadcrumbs" aria-label="Breadcrumbs">
+  {% include './icons/chevron-left.svg' %}
+  <a id="breadcrumb_link" class="breadcrumbs_link" href="{% url 'index' %}">
+    Consumerfinance.gov crawler
+  </a>
+</nav>
+
+<div class="block">
+  <h2>Common crawler searches </h2>
+</div>
+
+<div class="block">
+  <p>
+    The crawler stores a nightly snapshot of webpage data that you can search for
+    all sorts of useful things.
+  </p>
+  <p>
+    You can search for single terms or exact phrases. Examples:
+  </p>
+</div>
+
+<div class="block">
+  <h3>Title</h3>
+  <p>
+    You want a list of all pages with the word "Chopra" in the title.
+  </p>
+  <p>
+    <a href="{% url 'index' %}?search_type=title&q=Chopra">Search "Chopra"</a>
+  </p>
+</div>
+
+<div class="block">
+  <h3>URL</h3>
+  <p>
+    Find all instances of a string in the URL of a published cf.gov page.
+  </p>
+  <p>
+   Your stakeholder wants a list of all the pages in a given site section.
+  </p>
+  <p>
+    <a href="{% url 'index' %}?search_type=links&q={{ '/about-us/the-bureau/bureau-structure/' | urlencode }}">Search "/about-us/the-bureau/bureau-structure/"</a>
+  </p>
+</div>
+
+<div class="block">
+  <h3>Components</h3>
+  <p>
+    Search by
+    <a href="{% url 'components' %}">class names</a>
+    of our
+    <a href="https://cfpb.github.io/design-system/">design components</a>.
+    Partial searches also work: searching for "notification" will return pages
+    containing "m-notification", "m-notification__borderless", etc.
+  </p>
+  <p>
+    You're doing an audit of all occurrences of the notification pattern.
+  </p>
+  <p>
+    <a href="{% url 'index' %}?search_type=components&q=m-notification">Search "m-notification"</a>
+  </p>
+</div>
+
+<div class="block">
+  <h3>Links</h3>
+  <p>
+    Find all instances of a string in the URLs of links listed on a page,
+    excluding the header and footer.
+  </p>
+  <p>
+    You're looking for all instances of external links to TBD.
+  </p>
+  <p>
+    <a href="{% url 'index' %}?search_type=links&q=TBD">Search "TBD"</a>
+  </p>
+  <p>
+    You want to find and remediate accidental links to the content server.
+  </p>
+  <p>
+    <a href="{% url 'index' %}?search_type=links&q=content.consumerfinance.gov">Search "content.consumerfinance.gov"</a>
+  </p>
+  <p>
+    You want to find published cf.gov pages with broken links.
+  </p>
+  <p>
+    <a href="{% url 'index' %}?search_type=links&q=none">Search "none"</a>
+  </p>
+  <p>
+    You're looking for incorrectly formatted document links.
+  </p>
+  <p>
+    <a href="{% url 'index' %}?search_type=links&q={{ 'www.consumerfinance.gov/documents' | urlencode }}">Search "www.consumerfinance.gov/documents"</a>
+  </p>
+</div>
+
+<div class="block">
+  <h3>Full text</h3>
+  <p>
+    Find all instances of a term or exact phrase in the full text of the
+    &lt;body&gt; of a page, excluding the header and footer.
+  </p>
+  <p>
+    You're looking for specific phrasing or language that might need to be
+    updated because of a policy change.
+  </p>
+  <p>
+    <a href="{% url 'index' %}?search_type=text&q={{ 'medical debt' | urlencode }}">Search "medical debt"</a>
+  </p>
+</div>
+
+<div class="block">
+  <h3>HTML</h3>
+  <p>
+    You want to find and remediate manually-added line breaks.
+  </p>
+  <p>
+    <a href="{% url 'index' %}?search_type=html&q={{ '<br>' | urlencode }}">Search "&lt;br&gt;"</a>
+  </p>
+</div>
+{% endblock %}

--- a/viewer/viewer/urls.py
+++ b/viewer/viewer/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from django.views.generic import TemplateView
 
 from viewer import views
 
@@ -14,4 +15,5 @@ urlpatterns = [
         views.DownloadDatabaseView.as_view(),
         name="download-database",
     ),
+    path("help/", TemplateView.as_view(template_name="viewer/help.html"), name="help"),
 ]


### PR DESCRIPTION
This commit adds a stub help / common searches page, accessible atthe /help/ URL locally.

Content and design is loosely copied from internal designs. Seeinternal el-camino#636 for reference and discussion.