### PR TITLE
Better link search for external links

### DIFF
--- a/viewer/warc/search.py
+++ b/viewer/warc/search.py
@@ -1,3 +1,7 @@
+from urllib.parse import quote_plus
+
+from django.db.models import Q
+
 from warc.models import Page
 
 
@@ -19,10 +23,15 @@ def search_components(class_name_contains, include_class_names=False):
     return queryset.values(*values)
 
 
-def search_links(href_contains, include_hrefs=False):
-    queryset = Page.objects.prefetch_related("links").filter(
-        links__href__contains=href_contains
-    )
+def search_links(href_contains, include_hrefs=False, or_urlencoded=True):
+    queryset = Page.objects.prefetch_related("links")
+
+    href_filter = Q(links__href__contains=href_contains)
+
+    if or_urlencoded:
+        href_filter |= Q(links__href__contains=quote_plus(href_contains))
+
+    queryset = queryset.filter(href_filter)
 
     values = _page_values
 

--- a/wget_crawl.sh
+++ b/wget_crawl.sh
@@ -79,7 +79,7 @@ time wget \
     --ignore-case \
     --no-hsts \
     --reject '*.css,*.csv,*.do,*.doc,*.docx,*.epub,*.gif,*.ico,*.jpg,*.js,*.json,*.mp3,*.pdf,*.png,*.pptx,*.py,*.r,*.sas,*.sps,*.svg,*.tmp,*.txt,*.wav,*.webmanifest,*.woff,*.woff2,*.xls,*xlsx,*.xml,*.zip' \
-    --reject-regex "CatID=|NavCode=|_gl=|activity_type=|authors=|book=|categories=|chartType=|charttype=|clhx=|dateInterval=|date_received_min=|dateinterval=|entx=|fdx=|filter1_topics=|filter2_topics=|form-id=|gib=|gpl=|grade_level=|has_narrative=|hltx=|hous=|houx=|insi=|insl=|inst=|iped=|issue=|language=|lens=|mta=|oid=|othg=|othr=|othx=|parl=|pelg=|perl=|pid=|ppl=|product=|prvf=|prvi=|prvl=|q=|regs=|retx=|schg=|school_subject=|searchField=|search_field=|searchfield=|size=|sort=|stag=|subl=|tab=|taxx=|title=|topic=|topics=|totl=|tran=|trnx=|tuit=|unsl=|utm_campaign=|utm_medium=|utm_source=|wkst=" \
+    --reject-regex "CatID=|NavCode=|_gl=|activity_type=|authors=|book=|categories=|chartType=|charttype=|clhx=|dateInterval=|date_received_min=|dateinterval=|entx=|ext_url=|fdx=|filter1_topics=|filter2_topics=|form-id=|gib=|gpl=|grade_level=|has_narrative=|hltx=|hous=|houx=|insi=|insl=|inst=|iped=|issue=|language=|lens=|mta=|oid=|othg=|othr=|othx=|parl=|pelg=|perl=|pid=|ppl=|product=|prvf=|prvi=|prvl=|q=|regs=|retx=|schg=|school_subject=|searchField=|search_field=|searchfield=|signature=|size=|sort=|stag=|subl=|tab=|taxx=|title=|topic=|topics=|totl=|tran=|trnx=|tuit=|unsl=|utm_campaign=|utm_medium=|utm_source=|wkst=" \
     --recursive \
     --level="$depth" \
     --user-agent="crawsqueal" \


### PR DESCRIPTION
This PR enhances how link search works so that it includes results that link to a urlencoded version of the provided query string. For example, searching for `https://www.ftc.gov` will now match pages that both have links with `https://www.ftc.gov` but also pages with `https%3A%2F%2Fwww.ftc.gov`.

This is intended to support "external links" on consumerfinance.gov, e.g. links like [this one](https://www.consumerfinance.gov/external-site/?ext_url=https%3A%2F%2Fwww.facebook.com%2FCFPB&signature=mLDxq_fH8p2jVLrkPngPqkmwdsl_JEMSCoqZ74gLcCY) that point to an interstitial page but include an encoded version of the target URL in their query string parameters.

This PR also modifies the wget crawler script to skip these external link pages when crawling cf.gov; specifically those pages that have "ext_url" or "signature" query string parameters. This means that these external link pages won't be in the crawler search results.