### PR TITLE
Fix and document Python linting with black

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v3
       with:

--- a/README.md
+++ b/README.md
@@ -195,6 +195,22 @@ To run Python unit tests, use [`tox`](https://tox.wiki/en/latest/):
 tox
 ```
 
+### Code formatting
+
+This project uses [Black](https://github.com/psf/black) as a Python code formatter.
+
+To check if your changes to project code match the desired coding style:
+
+```
+black . --check
+```
+
+You can fix any problems by running:
+
+```
+black .
+```
+
 ### Sample database file
 
 This repository includes a sample database file ([sample.sqlite3](./sample.sqlite3)).


### PR DESCRIPTION
The current GitHub Action for Python linting using black wasn't actually doing anything. This PR fixes that, and adds documentation about black to the project README.