### PR TITLE
Bump Django version from 4.0.3 to 4.0.6

### DIFF
--- a/viewer/requirements.txt
+++ b/viewer/requirements.txt
@@ -2,7 +2,7 @@ asgiref==3.5.0
 click==8.1.3
 cssselect==1.1.0
 distlib==0.3.4
-Django==4.0.3
+Django==4.0.6
 django-click==2.3.0
 django-debug-toolbar==3.4.0
 django-filter==22.1


### PR DESCRIPTION
Django version 4.0.3 has several high severity security bugs fixed in more recent versions:

https://docs.djangoproject.com/en/4.0/releases/4.0.4/
https://docs.djangoproject.com/en/4.0/releases/4.0.6/

These patch version upgrades shouldn't affect any functionality in this project.

To test, with the project virtualenv activated, re-run

```
pip install -r viewer/requirements.txt
```

and confirm that all functionality continues to work.