### PR TITLE
Add additional footer links

### DIFF
--- a/viewer/viewer/templates/viewer/base.html
+++ b/viewer/viewer/templates/viewer/base.html
@@ -76,6 +76,7 @@
               Last website crawl: {{ crawl_stats.start }} - {{ crawl_stats.end}}
               ({{ crawl_stats.duration | precisedelta }})
             </li>
+            <!-- prettier-ignore -->
             <li>
               Explore the data via API:
               <a class="m-list_link a-link"
@@ -87,6 +88,7 @@
               <a class="m-list_link a-link"
                 href="{% url 'redirects' %}?format=api">redirects</a>.
             </li>
+            <!-- prettier-ignore -->
             <li>
               Download CSV
               <a class="m-list_link a-link a-link__icon"
@@ -111,6 +113,7 @@
                     d="M11.16 16.153a.477.477 0 0 1-.476.475H1.316a.476.476 0 0 1-.475-.475V3.046a.476.476 0 0 1 .475-.475h6.95l2.893 2.893zm-1.11-9.925H8.059a.575.575 0 0 1-.574-.573V3.679H1.95v11.84h8.102zm-1.234 5.604L6.388 14.26a.554.554 0 0 1-.784 0l-2.428-2.428a.554.554 0 1 1 .783-.784l1.483 1.482V7.41a.554.554 0 1 1 1.108 0v5.12l1.482-1.482a.554.554 0 0 1 .784.783z"></path>
                 </svg></a>.
             </li>
+            <!-- prettier-ignore -->
             <li class="m-list_item">
               <a
                 class="m-list_link a-link a-link__icon"

--- a/viewer/viewer/templates/viewer/base.html
+++ b/viewer/viewer/templates/viewer/base.html
@@ -76,11 +76,46 @@
               Last website crawl: {{ crawl_stats.start }} - {{ crawl_stats.end}}
               ({{ crawl_stats.duration | precisedelta }})
             </li>
+            <li>
+              Explore the data via API:
+              <a class="m-list_link a-link"
+                href="{% url 'index' %}?format=api">pages</a>,
+              <a class="m-list_link a-link"
+                href="{% url 'components' %}?format=api">components</a>,
+              <a class="m-list_link a-link"
+                href="{% url 'errors' %}?format=api">errors</a>, and
+              <a class="m-list_link a-link"
+                href="{% url 'redirects' %}?format=api">redirects</a>.
+            </li>
+            <li>
+              Download CSV
+              <a class="m-list_link a-link a-link__icon"
+                href="{% url 'errors' %}?format=csv">
+                <span class="a-link_text">website errors (including 404s)</span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 12 19"
+                  class="cf-icon-svg">
+                  <path
+                    d="M11.16 16.153a.477.477 0 0 1-.476.475H1.316a.476.476 0 0 1-.475-.475V3.046a.476.476 0 0 1 .475-.475h6.95l2.893 2.893zm-1.11-9.925H8.059a.575.575 0 0 1-.574-.573V3.679H1.95v11.84h8.102zm-1.234 5.604L6.388 14.26a.554.554 0 0 1-.784 0l-2.428-2.428a.554.554 0 1 1 .783-.784l1.483 1.482V7.41a.554.554 0 1 1 1.108 0v5.12l1.482-1.482a.554.554 0 0 1 .784.783z"></path>
+                </svg>
+              </a> and
+              <a class="m-list_link a-link a-link__icon"
+                href="{% url 'redirects' %}?format=csv">
+                <span class="a-link_text">website redirects</span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 12 19"
+                  class="cf-icon-svg">
+                  <path
+                    d="M11.16 16.153a.477.477 0 0 1-.476.475H1.316a.476.476 0 0 1-.475-.475V3.046a.476.476 0 0 1 .475-.475h6.95l2.893 2.893zm-1.11-9.925H8.059a.575.575 0 0 1-.574-.573V3.679H1.95v11.84h8.102zm-1.234 5.604L6.388 14.26a.554.554 0 0 1-.784 0l-2.428-2.428a.554.554 0 1 1 .783-.784l1.483 1.482V7.41a.554.554 0 1 1 1.108 0v5.12l1.482-1.482a.554.554 0 0 1 .784.783z"></path>
+                </svg></a>.
+            </li>
             <li class="m-list_item">
               <a
                 class="m-list_link a-link a-link__icon"
                 href="{% url 'download-database' %}">
-                <span class="a-link_text">Download raw SQLite database</span>
+                <span class="a-link_text">Download the raw SQLite database</span>
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 12 19"
@@ -91,11 +126,16 @@
               </a>
               ({{ crawl_stats.database_size | filesizeformat }}) to
               <a
-                class="m-list_link"
+                class="m-list_link a-link a-link__icon"
                 href="https://github.com/cfpb/crawsqueal#how-to-query-the-crawler-database">
-                explore the data locally
-              </a>
-              .
+                <span class="a-link_text">query the data locally</span>
+                <svg
+                  class="cf-icon-svg"
+                  viewBox="0 0 14 19"
+                  xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M13.017 3.622v4.6a.554.554 0 0 1-1.108 0V4.96L9.747 7.122a1.65 1.65 0 0 1 .13.646v5.57A1.664 1.664 0 0 1 8.215 15h-5.57a1.664 1.664 0 0 1-1.662-1.663v-5.57a1.664 1.664 0 0 1 1.662-1.662h5.57A1.654 1.654 0 0 1 9 6.302l2.126-2.126H7.863a.554.554 0 1 1 0-1.108h4.6a.554.554 0 0 1 .554.554zM8.77 8.1l-2.844 2.844a.554.554 0 0 1-.784-.783l2.947-2.948H2.645a.555.555 0 0 0-.554.555v5.57a.555.555 0 0 0 .554.553h5.57a.555.555 0 0 0 .554-.554z"></path>
+                </svg></a>.
             </li>
           </ul>
         </div>


### PR DESCRIPTION
This change modifies the base page template to add footer links to:

- Download website errors (including 404s) as CSV
- Download website redirects as CSV
- Explore website data via API: pages, components, errors, redirects

With this change, the footer now looks like this:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/654645/182159878-f736cac7-c54d-4f6b-8918-6196f9ff85a2.png">