### PR TITLE
Minor frontend link fixes

### DIFF
--- a/viewer/viewer/templates/viewer/page_list.html
+++ b/viewer/viewer/templates/viewer/page_list.html
@@ -66,22 +66,30 @@
 
 {% if previous or next %}
 <div class="results_paginator">
+  <!-- prettier-ignore -->
   <nav class="m-pagination" role="navigation" aria-label="Pagination">
-    {% if previous %}
-    <a class="a-btn m-pagination_btn-prev" href="{{ previous }}"></a>
-    {% else %}
-    <a class="a-btn a-btn__disabled m-pagination_btn-prev">
+    <a
+      {% if previous %}
+      class="a-btn m-pagination_btn-prev"
+      href="{{ previous }}"
+      {% else %}
+      class="a-btn a-btn__disabled m-pagination_btn-prev"
       {% endif %}
+    >
       <span class="a-btn_icon a-btn_icon__on-left">
         {% include './icons/chevron-left.svg' %}
       </span>
       Previous
     </a>
-    {% if next %}
-    <a class="a-btn m-pagination_btn-next" href="{{ next }}"></a>
-    {% else %}
-    <a class="a-btn a-btn__disabled m-pagination_btn-next">
-      {% endif %} Next
+    <a
+      {% if next %}
+      class="a-btn m-pagination_btn-next"
+      href="{{ next }}"
+      {% else %}
+      class="a-btn a-btn__disabled m-pagination_btn-next"
+      {% endif %}
+    >
+      Next
       <span class="a-btn_icon a-btn_icon__on-right">
         {% include './icons/chevron-right.svg' %}
       </span>

--- a/viewer/viewer/templates/viewer/page_list.html
+++ b/viewer/viewer/templates/viewer/page_list.html
@@ -39,20 +39,18 @@
 <div class="results_list">
   <ul class="m-list">
     {% for page in results %}
+    <!-- prettier-ignore -->
     <li class="results_item">
       <h4>
         <a class="a-link a-link__icon" href="{{ page.url }}">
-          <span class="a-link_text u-truncate">
-            {{ page.title | strip_title_suffix }}
-          </span>
+          <span class="a-link_text u-truncate">{{ page.title | strip_title_suffix }}</span>
           <svg
             class="cf-icon-svg"
             viewBox="0 0 14 19"
             xmlns="http://www.w3.org/2000/svg">
             <path
               d="M13.017 3.622v4.6a.554.554 0 0 1-1.108 0V4.96L9.747 7.122a1.65 1.65 0 0 1 .13.646v5.57A1.664 1.664 0 0 1 8.215 15h-5.57a1.664 1.664 0 0 1-1.662-1.663v-5.57a1.664 1.664 0 0 1 1.662-1.662h5.57A1.654 1.654 0 0 1 9 6.302l2.126-2.126H7.863a.554.554 0 1 1 0-1.108h4.6a.554.554 0 0 1 .554.554zM8.77 8.1l-2.844 2.844a.554.554 0 0 1-.784-.783l2.947-2.948H2.645a.555.555 0 0 0-.554.555v5.57a.555.555 0 0 0 .554.553h5.57a.555.555 0 0 0 .554-.554z"></path>
-          </svg>
-        </a>
+          </svg></a>
       </h4>
       <div class="u-truncate">{{ page.url }}</div>
       <a


### PR DESCRIPTION
1. The pagination links were inadvertently broken in 6f69fc733fae2d90de65fa67c47a7a8b8ed28153; to test this you need a local DB with more than one page of results. Bug is also visible on the production site currently.
2. The page detail links currently have an extra bit of underline, unfortunately due to how Prettier tries to rearrange tags (see commit message for greater detail).

|Before|After|
|-|-|
|<img width="438" alt="image" src="https://user-images.githubusercontent.com/654645/182168321-07d13214-7ac1-4567-8e45-302cb161673d.png">|<img width="428" alt="image" src="https://user-images.githubusercontent.com/654645/182168382-a60d7808-4f04-4658-b8da-01ab60f7f027.png">|
