### PR TITLE
Fix link from components page

### DIFF
--- a/viewer/viewer/templates/viewer/component_list.html
+++ b/viewer/viewer/templates/viewer/component_list.html
@@ -19,7 +19,7 @@
     {% for component in results %}
     <li class="results_item">
       <a
-        href="{% url 'index %}?search_type=components&q={{ component.class_name | escape }}">
+        href="{% url 'index' %}?search_type=components&q={{ component.class_name | escape }}">
         {{ component.class_name }}
       </a>
     </li>


### PR DESCRIPTION
To test, run with a database that has some design components:

http://localhost:8000/components/

(Or confirm that the page is currently broken in production, and that this will fix it.)