### PR TITLE
Adjust layout and implement component section links

### DIFF
--- a/viewer/viewer/static_src/crawsqueal.css
+++ b/viewer/viewer/static_src/crawsqueal.css
@@ -91,3 +91,8 @@ code.language-html {
 .m-list_item {
     max-width: 60em !important;
 }
+
+.o-header_alt {
+    margin-top: 30px;
+    margin-bottom: 15px;
+}

--- a/viewer/viewer/templates/viewer/help.html
+++ b/viewer/viewer/templates/viewer/help.html
@@ -6,17 +6,12 @@
   </a>
 </nav>
 
-<div class="block">
-  <h2>Common crawler searches</h2>
-</div>
+<h2 class="o-header_alt">Common crawler searches</h2>
 
-<div class="block">
-  <p>
-    The crawler stores a nightly snapshot of webpage data that you can search
-    for all sorts of useful things.
-  </p>
-  <p>You can search for single terms or exact phrases. Examples:</p>
-</div>
+<p>
+  The crawler stores a nightly snapshot of webpage data that you can search for
+  all sorts of useful things. You can search for single terms or exact phrases.
+</p>
 
 <div class="block">
   <h2>Title</h2>
@@ -51,8 +46,8 @@
     Search by
     <a href="{% url 'components' %}">class names</a>
     of our
-    <a href="https://cfpb.github.io/design-system/">design components</a>
-    . Partial searches also work: searching for "notification" will return pages
+    <a href="https://cfpb.github.io/design-system/">design components</a>.
+    Partial searches also work: searching for "notification" will return pages
     containing "m-notification", "m-notification__borderless", etc.
   </p>
   <p class="u-example_text">Examples</p>

--- a/viewer/viewer/templates/viewer/search_form.html
+++ b/viewer/viewer/templates/viewer/search_form.html
@@ -41,7 +41,15 @@
         <input class="a-radio" type="radio" value="components" id="search_type_components" name="search_type"{% if request.query_params.search_type == 'components' %} checked{% endif %}>
         <label class="a-label" for="search_type_components">
           Components
-          <span>Search by class names of our components</span>
+          <span>
+            <!-- prettier-ignore -->
+            <p>
+              Search by
+              <a href="{% url 'components' %}">class names</a>
+              of our
+              <a href="https://cfpb.github.io/design-system/">design components</a>
+            </p>
+          </span>
         </label>
       </div>
       <div class="m-form-field m-form-field__radio reg-radio">


### PR DESCRIPTION
Adjusted Help page layout based on Jenn's feedback and now have proper links under the `Component` radio button in the search panel.