### PR TITLE
Give CSV downloads better filenames

### DIFF
--- a/viewer/viewer/context_processors.py
+++ b/viewer/viewer/context_processors.py
@@ -6,7 +6,7 @@ from django.db.models import Count, Max, Min
 from warc.models import Page
 
 
-def crawl_stats(request):
+def crawl_stats(request=None):
     crawl_stats = Page.objects.values("timestamp").aggregate(
         count=Count("timestamp"),
         start=Min("timestamp"),


### PR DESCRIPTION
Give CSV downloads better filenames that indicate the type of the data and the date of the crawl it is associated with, e.g.

pages-20220801.csv
components-20220801.csv
errors-20220801.csv
redirects-20220801.csv