### PR TITLE
Set default timezone to America/New_York

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -101,7 +101,7 @@ DATABASES = {
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "America/New_York"
 
 USE_I18N = True
 


### PR DESCRIPTION
Database timestamps are in UTC, but we want them to display on the frontend in US Eastern timezone (technically "America/New_York"). This change makes that happen.

|Before|After|
|-|-|
|<img width="200" alt="image" src="https://user-images.githubusercontent.com/654645/184003755-d8c33ae4-c2e7-4bd6-8f07-ef5700e9518b.png">|<img width="211" alt="image" src="https://user-images.githubusercontent.com/654645/184003810-3aeea20b-ad88-45fa-9af6-97a6069c6365.png">|