### PR TITLE
Minor updates to search results text

### DIFF
--- a/viewer/templatetags/search_results.py
+++ b/viewer/templatetags/search_results.py
@@ -1,4 +1,5 @@
 from django import template
+from django.contrib.humanize.templatetags.humanize import intcomma
 from django.template.defaultfilters import pluralize
 
 
@@ -14,7 +15,7 @@ def results_summary(context, truncate_q_at=24):
     search_type = request.GET.get("search_type")
 
     if not q or not search_type:
-        return f"Showing {count} total page{pluralize(count)}"
+        return f"Showing {intcomma(count)} total page{pluralize(count)}"
 
     search_name = {
         "title": "the page title",
@@ -25,7 +26,7 @@ def results_summary(context, truncate_q_at=24):
         "html": "page HTML",
     }[search_type]
 
-    count_str = str(count) if count else "No"
+    count_str = intcomma(count) if count else "No"
     truncated_q = f"{q[:truncate_q_at]}..." if len(q) > truncate_q_at else q
 
     return f'{count_str} page{pluralize(count)} with "{truncated_q}" in {search_name}'

--- a/viewer/templatetags/search_results.py
+++ b/viewer/templatetags/search_results.py
@@ -15,7 +15,10 @@ def results_summary(context, truncate_q_at=24):
     search_type = request.GET.get("search_type")
 
     if not q or not search_type:
-        return f"Showing {intcomma(count)} total page{pluralize(count)}"
+        if not count:
+            return "There are no indexed pages"
+        else:
+            return f"Showing all {intcomma(count)} indexed page{pluralize(count)}"
 
     search_name = {
         "title": "the page title",

--- a/viewer/tests/test_templatetags.py
+++ b/viewer/tests/test_templatetags.py
@@ -12,7 +12,7 @@ class ResultsSummaryTests(SimpleTestCase):
 
     def check_default_response(self, **kwargs):
         context = self.make_context(**kwargs)
-        self.assertEqual(results_summary(context), "Showing 1,000 total pages")
+        self.assertEqual(results_summary(context), "Showing all 1,000 indexed pages")
 
     def test_no_query_params(self):
         self.check_default_response()
@@ -79,3 +79,6 @@ class ResultsSummaryTests(SimpleTestCase):
             {"search_type": "html", "q": "foo"},
             '1,000 pages with "foo" in page HTML',
         )
+
+    def test_no_results(self):
+        self.check_response({"count": 0}, "There are no indexed pages")

--- a/viewer/tests/test_templatetags.py
+++ b/viewer/tests/test_templatetags.py
@@ -4,7 +4,7 @@ from viewer.templatetags.search_results import results_summary
 
 
 class ResultsSummaryTests(SimpleTestCase):
-    def make_context(self, count=100, **kwargs):
+    def make_context(self, count=1000, **kwargs):
         return {
             "request": RequestFactory().get("/", kwargs),
             "count": count,
@@ -12,7 +12,7 @@ class ResultsSummaryTests(SimpleTestCase):
 
     def check_default_response(self, **kwargs):
         context = self.make_context(**kwargs)
-        self.assertEqual(results_summary(context), "Showing 100 total pages")
+        self.assertEqual(results_summary(context), "Showing 1,000 total pages")
 
     def test_no_query_params(self):
         self.check_default_response()
@@ -35,7 +35,7 @@ class ResultsSummaryTests(SimpleTestCase):
     def test_title(self):
         self.check_response(
             {"search_type": "title", "q": "foo"},
-            '100 pages with "foo" in the page title',
+            '1,000 pages with "foo" in the page title',
         )
 
     def test_title_single_result(self):
@@ -47,35 +47,35 @@ class ResultsSummaryTests(SimpleTestCase):
     def test_title_truncates(self):
         self.check_response(
             {"search_type": "title", "q": "abcdefghijklmnopqrstuvwxyz"},
-            '100 pages with "abcdefghijklmnopqrstuvwx..." in the page title',
+            '1,000 pages with "abcdefghijklmnopqrstuvwx..." in the page title',
         )
 
     def test_url(self):
         self.check_response(
             {"search_type": "url", "q": "foo"},
-            '100 pages with "foo" in the page URL',
+            '1,000 pages with "foo" in the page URL',
         )
 
     def test_components(self):
         self.check_response(
             {"search_type": "components", "q": "foo"},
-            '100 pages with "foo" in components',
+            '1,000 pages with "foo" in components',
         )
 
     def test_links(self):
         self.check_response(
             {"search_type": "links", "q": "foo"},
-            '100 pages with "foo" in link URLs',
+            '1,000 pages with "foo" in link URLs',
         )
 
     def test_text(self):
         self.check_response(
             {"search_type": "text", "q": "foo"},
-            '100 pages with "foo" in full text',
+            '1,000 pages with "foo" in full text',
         )
 
     def test_html(self):
         self.check_response(
             {"search_type": "html", "q": "foo"},
-            '100 pages with "foo" in page HTML',
+            '1,000 pages with "foo" in page HTML',
         )


### PR DESCRIPTION
1. Add comma to numbers in summary results: Results should be "1,000 pages", not "1000 pages".
2. Update results strings for null search: "Showing all 1,000 indexed pages" OR "There are no indexed pages" if for some weird reason the database happens to be empty. See internal el-camino#641#issuecomment-318563 for context.