### PR TITLE
Limit pages to single domain by default

### DIFF
--- a/crawler/management/commands/warc_to_db.py
+++ b/crawler/management/commands/warc_to_db.py
@@ -33,7 +33,14 @@ from crawler.writer import DatabaseWriter
     default=False,
     help="Do not prompt the user for input of any kind.",
 )
-def command(warc, db_filename, max_pages, recreate, noinput):
+@click.option(
+    "--multiple-domains/--no-multiple-domains",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Limit pages to the first domain seen.",
+)
+def command(warc, db_filename, max_pages, recreate, noinput, multiple_domains):
     if os.path.exists(db_filename):
         if not recreate:
             if noinput:
@@ -61,7 +68,9 @@ def command(warc, db_filename, max_pages, recreate, noinput):
     click.echo("Reading WARC content into database tables...")
     writer = DatabaseWriter(db_alias)
 
-    for instance in generate_instances(warc, max_pages=max_pages):
+    for instance in generate_instances(
+        warc, max_pages=max_pages, single_domain_only=not multiple_domains
+    ):
         writer.write(instance)
 
     writer.analyze()


### PR DESCRIPTION
Currently the crawl result can generate pages that live off of the www.consumerfinance.gov domain, due to a quirk in the way that wget works and generates its output:

<img width="1193" alt="image" src="https://user-images.githubusercontent.com/654645/184386902-b6821f60-a3a7-4e2d-a061-83ee367ccc9b.png">

Specifically, even though we tell wget to only crawl URLs on www.consumerfinance.gov, if we have redirects that point off the site, it will crawl those pages. For example:

www.cf.gov/something -> somewhereelse.com/something

This change makes it so these pages are discarded when we convert from the wget WARC output to the SQLite database.

This behavior can be controlled by a new `--multiple-domains` / `--no-multiple-domains` flag to the warc_to_db management command.