### PR TITLE
Add timezone to displayed timestamps

### DIFF
--- a/viewer/templates/viewer/base_search.html
+++ b/viewer/templates/viewer/base_search.html
@@ -1,4 +1,4 @@
-{% extends './base.html' %} {% block content %}
+{% extends './base.html' %} {% load viewer %} {% block content %}
 <div class="block block__sub">
   <div class="content_wrapper search_form">
     <h1>Consumerfinance.gov web page index</h1>
@@ -13,7 +13,7 @@
     {% endblock intro %}
     <div class="u-crawl_date">
       <span class="u-crawl_text">Data last updated: </span>
-      <p><a href="#last-crawl">{{ crawl_stats.start }}</a></p>
+      <p><a href="#last-crawl">{{ crawl_stats.start | format_datetime }}</a></p>
     </div>
   </div>
 </div>

--- a/viewer/templates/viewer/page_list.html
+++ b/viewer/templates/viewer/page_list.html
@@ -1,4 +1,5 @@
-{% extends './base_search.html' %} {% load humanize %} {% load search_results %}
+{% extends './base_search.html' %} {% load humanize %} {% load viewer %}
+<!-- prettier-ignore -->
 {% block content_main %}
 <div class="results_count">
   <h2 class="h3">{% results_summary %}</h2>
@@ -120,7 +121,7 @@
     <span id="last-crawl" class="u-crawl_text u-bold_text"
       >Data last updated:
     </span>
-    <p>{{ crawl_stats.start }}</p>
+    <p>{{ crawl_stats.start | format_datetime }}</p>
   </div>
   <ul class="m-list">
     <!-- prettier-ignore -->

--- a/viewer/templatetags/viewer.py
+++ b/viewer/templatetags/viewer.py
@@ -1,9 +1,15 @@
 from django import template
 from django.contrib.humanize.templatetags.humanize import intcomma
-from django.template.defaultfilters import pluralize
+from django.template.defaultfilters import date, pluralize
+from django.templatetags.tz import localtime
 
 
 register = template.Library()
+
+
+@register.filter
+def format_datetime(dt):
+    return date(localtime(dt), "N j, Y, H:i a T")
 
 
 @register.simple_tag(takes_context=True)

--- a/viewer/tests/test_templatetags.py
+++ b/viewer/tests/test_templatetags.py
@@ -1,6 +1,16 @@
+from datetime import datetime, timezone
+
 from django.test import RequestFactory, SimpleTestCase
 
-from viewer.templatetags.search_results import results_summary
+from viewer.templatetags.viewer import format_datetime, results_summary
+
+
+class FormatDatetimeTests(SimpleTestCase):
+    def test_format(self):
+        self.assertEqual(
+            format_datetime(datetime(2022, 8, 11, 16, 54, 29, tzinfo=timezone.utc)),
+            "Aug. 11, 2022, 12:54 p.m. EDT",
+        )
 
 
 class ResultsSummaryTests(SimpleTestCase):


### PR DESCRIPTION
Timestamp format: "Aug. 11, 2022, 12:54 p.m. EDT"

This new format appears in the header and footer on the search page.