### PR TITLE
Bug fix: Times should display in 12-hour format

### DIFF
--- a/viewer/templatetags/viewer.py
+++ b/viewer/templatetags/viewer.py
@@ -9,7 +9,7 @@ register = template.Library()
 
 @register.filter
 def format_datetime(dt):
-    return date(localtime(dt), "N j, Y, H:i a T")
+    return date(localtime(dt), "N j, Y, g:i a T")
 
 
 @register.simple_tag(takes_context=True)

--- a/viewer/tests/test_templatetags.py
+++ b/viewer/tests/test_templatetags.py
@@ -12,6 +12,12 @@ class FormatDatetimeTests(SimpleTestCase):
             "Aug. 11, 2022, 12:54 p.m. EDT",
         )
 
+    def test_format_am(self):
+        self.assertEqual(
+            format_datetime(datetime(2022, 8, 11, 12, 54, 29, tzinfo=timezone.utc)),
+            "Aug. 11, 2022, 8:54 a.m. EDT",
+        )
+
 
 class ResultsSummaryTests(SimpleTestCase):
     def make_context(self, count=1000, **kwargs):


### PR DESCRIPTION
Currently times display incorrectly, for example 8:00 PM displays as 20:00 PM. This bug corrects the time formatting to use 12-hour format without a leading zero for the hour, e.g. 8:00 AM or 8:00 PM.