### PR TITLE
Remove hardcoded Python version in fabfile

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -58,7 +58,7 @@ def deploy(conn):
     # Build the viewer app and update any dependencies.
     with conn.cd(SOURCE_ROOT):
         conn.run("yarn && yarn build")
-        conn.run("python3.8 -m venv venv")
+        conn.run("python -m venv venv")
 
         with conn.prefix("source venv/bin/activate"):
             conn.run("pip install -r requirements/base.txt")


### PR DESCRIPTION
Currently the deployment fabfile has a hardcoded reference to Python 3.8, but there's no reason to hardcode this. We might want to run on Python 3.10, or whatever version of Python is installed on the server.