### PR TITLE
Fix: Give logrotate permission to rotate logs

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -179,6 +179,10 @@ def deploy(conn):
     conn.sudo(f"chown root:root {LOGROTATE_PATH}")
     conn.sudo(f"chmod 644 {LOGROTATE_PATH}")
 
+    # SELinux: Allow logrotate to write to log files.
+    # This gets persisted to /etc/selinux/targeted/contexts/files/file_contexts.local
+    conn.sudo(f"semanage fcontext -a -t var_log_t '{LOG_DIR}(/.*)?'")
+
     # Configure gunicorn to run via systemd.
     print("Configuring gunicorn service")
     gunicorn_config = StringIO(


### PR DESCRIPTION
When using the fabfile configuration/deploy scripts, currently SELinux will block logrotate from rotating the log files because /var/log/crawsqueal is owned by the ec2-user account.

This change adds the necessary SELinux configuration so that logrotate should work properly (via the var_log_t permission).