### PR TITLE
Set favicon to 🪱

### DIFF
--- a/viewer/templates/viewer/base.html
+++ b/viewer/templates/viewer/base.html
@@ -10,6 +10,8 @@
       content="width=device-width, initial-scale=1, minimum-scale=1" />
     <!-- prettier-ignore -->
     <title>{% block title %}Consumerfinance.gov web page index{% endblock %}</title>
+    <!-- prettier-ignore -->
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🪱</text></svg>" />
     <link rel="stylesheet" href="{% static 'main.css' %}" />
     <link rel="stylesheet" href="{% static 'crawsqueal.css' %}" />
   </head>


### PR DESCRIPTION
SVG favicons are currently supported by most major browsers except for Safari: https://caniuse.com/link-icon-svg