### PR TITLE
Fix: Skip pages with missing title tags

### DIFF
--- a/crawler/reader.py
+++ b/crawler/reader.py
@@ -124,6 +124,9 @@ def make_instance_from_warc_record(
     title = title_tag.text.strip() if title_tag is not None else None
     language = tree.find(".").get("lang")
 
+    if title is None:
+        return
+
     body = get_body(tree)
 
     if body is not None:


### PR DESCRIPTION
Currently if for some reason a page that is otherwise valid (returned an HTTP 200 response and is of type text/html) is missing a <title> tag, the warc_to_db command will fail because titles are not optional.

It might be possible to add support for optional titles, but this would require some changes to the UI (to know how to display links to the page, for example).

This change skips any pages that show up in the WARC like this.