### PR TITLE
Graceful handling of empty databases

### DIFF
--- a/viewer/context_processors.py
+++ b/viewer/context_processors.py
@@ -13,9 +13,17 @@ def crawl_stats(request=None):
         end=Max("timestamp"),
     )
 
+    crawl_start = crawl_stats["start"]
+    crawl_end = crawl_stats["end"]
+
+    if crawl_start and crawl_end:
+        duration = crawl_end - crawl_start
+    else:
+        duration = None
+
     crawl_stats.update(
         {
-            "duration": crawl_stats["end"] - crawl_stats["start"],
+            "duration": duration,
             "database_size": os.path.getsize(settings.CRAWL_DATABASE),
         }
     )

--- a/viewer/templates/viewer/base_search.html
+++ b/viewer/templates/viewer/base_search.html
@@ -10,11 +10,12 @@
         <a href="{% url 'help' %}">search for all sorts of useful things</a>.
       </p>
     </div>
-    {% endblock intro %}
+    {% endblock intro %} {% if crawl_stats.start %}
     <div class="u-crawl_date">
       <span class="u-crawl_text">Data last updated: </span>
       <p><a href="#last-crawl">{{ crawl_stats.start | format_datetime }}</a></p>
     </div>
+    {% endif %}
   </div>
 </div>
 

--- a/viewer/templates/viewer/page_list.html
+++ b/viewer/templates/viewer/page_list.html
@@ -118,10 +118,12 @@
 <div class="o-well o-well_alt">
   <div class="lead-paragraph">Discover more</div>
   <div class="u-crawl_date">
+    {% if crawl_stats.start %}
     <span id="last-crawl" class="u-crawl_text u-bold_text"
       >Data last updated:
     </span>
     <p>{{ crawl_stats.start | format_datetime }}</p>
+    {% endif %}
   </div>
   <ul class="m-list">
     <!-- prettier-ignore -->

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -70,12 +70,13 @@ class BetterCSVsMixin:
         response = super().finalize_response(*args, **kwargs)
 
         if self.is_rendering_csv:
-            crawl_start = crawl_stats()["crawl_stats"]["end"]
-            response["Content-Disposition"] = (
-                "attachment; filename="
-                f"{self.csv_basename}-"
-                f"{crawl_start.strftime('%Y%m%d')}.csv"
-            )
+            filename = self.csv_basename
+
+            crawl_start = crawl_stats()["crawl_stats"]["start"]
+            if crawl_start:
+                filename += f"-{crawl_start.strftime('%Y%m%d')}"
+
+            response["Content-Disposition"] = f"attachment; filename={filename}.csv"
 
         return response
 


### PR DESCRIPTION
If the crawl database has zero pages, the viewer application will currently return an unhandled 500 error.

This commit fixes the viewer application so that it gracefully handles empty databases. It also hides the "Data last updated" indication if there is no date to display.